### PR TITLE
Support Ingress v1

### DIFF
--- a/deploy/charts/kube-oidc-proxy/templates/ingress.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kube-oidc-proxy.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -28,9 +28,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: https
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: https
         {{- end }}
   {{- end }}
 {{- end }}

--- a/deploy/charts/kube-oidc-proxy/templates/ingress.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/ingress.yaml
@@ -21,6 +21,9 @@ spec:
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+{{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}

--- a/deploy/charts/kube-oidc-proxy/values.yaml
+++ b/deploy/charts/kube-oidc-proxy/values.yaml
@@ -86,6 +86,8 @@ ingress:
     - host: chart-example.local
       paths: []
 
+  # ingressClassName: ''
+
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
Without this, I'm not able to install this on a recent Kubernetes release from the chart

```
✗ HelmRelease reconciliation failed: Helm install failed: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Ingress" in version "extensions/v1beta1"
```