### PR TITLE
serve on container port 8443

### DIFF
--- a/deploy/charts/kube-oidc-proxy/templates/deployment.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
-        - containerPort: 443
+        - containerPort: 8443
         - containerPort: 8080
         readinessProbe:
           httpGet:
@@ -38,7 +38,7 @@ spec:
           periodSeconds: 10
         command: ["kube-oidc-proxy"]
         args:
-          - "--secure-port=443"
+          - "--secure-port=8443"
           - "--tls-cert-file=/etc/oidc/tls/crt.pem"
           - "--tls-private-key-file=/etc/oidc/tls/key.pem"
           - "--oidc-client-id=$(OIDC_CLIENT_ID)"

--- a/deploy/charts/kube-oidc-proxy/templates/service.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/service.yaml
@@ -19,7 +19,7 @@ spec:
 {{- end }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: 443
+      targetPort: 8443
       protocol: TCP
       name: https
   selector:


### PR DESCRIPTION
The container must run as root to bind to port 443.  Serving on 8443 allows the container to run as an unprivileged user.