### PR TITLE
Set usable and safe client-side rate limit on Kubernetes client

### DIFF
--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -57,6 +57,10 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 				}
 			}
 
+			// Set a known working client-side rate limit.
+			restConfig.QPS = 100
+			restConfig.Burst = 100
+
 			// Initialise token reviewer if enabled
 			var tokenReviewer *tokenreview.TokenReview
 			if opts.App.TokenPassthrough.Enabled {


### PR DESCRIPTION
#### Note: Same PR as https://github.com/jetstack/kube-oidc-proxy/pull/203 :) many thanks for the effort of this fork!

Hi!

First of all, thanks for this awesome project!

We started using kube-oidc-proxy to access our clusters. Normally when a user uses the proxy to access a Kubernetes cluster, there isn't any problem, and works like a charm. However, when a machine/bot/app (e.g ArgoCD) starts using it the proxy starts rate-limiting the requests because the Kubernetes client client-side rate limit is not configured.

For example, our Argo CD installation failed constantly connecting to the clusters (get status, send actions...) because of this client-side rate limit.

This PR adds a safe default that it's known that works correctly:

QPS: 100
Burst: 100
Some projects that configure this to don't get this kind of problems:

[Prometheus operator](https://github.com/prometheus-operator/prometheus-operator/blob/6b60cbcf4beaf679744077bc6f5b7e758f668658/pkg/k8sutil/k8sutil.go#L96-L97)
[Cert manager](https://github.com/jetstack/cert-manager/blob/b5003b52d0440db7fcb5b41b2f2a799a1d1171b3/cmd/controller/app/options/options.go#L120-L121)