### PR TITLE
Add flags to be able to configure kubernetes client throttling

### DIFF
--- a/cmd/app/options/client.go
+++ b/cmd/app/options/client.go
@@ -10,6 +10,9 @@ import (
 
 type ClientOptions struct {
 	*genericclioptions.ConfigFlags
+
+	KubeClientQPS   float32
+	KubeClientBurst int
 }
 
 func NewClientOptions(nfs *cliflag.NamedFlagSets) *ClientOptions {
@@ -27,6 +30,15 @@ func NewClientOptions(nfs *cliflag.NamedFlagSets) *ClientOptions {
 
 func (c *ClientOptions) AddFlags(fs *pflag.FlagSet) *ClientOptions {
 	c.ConfigFlags.AddFlags(fs)
+
+	// Extra flags
+	fs.Float32Var(&c.KubeClientQPS, "kube-client-qps", c.KubeClientQPS, "Sets the QPS on the app "+
+		"kubernetes client, this will configure throttling on requests sent to the apiserver "+
+		"(If not set, it will use client default ones)")
+	fs.IntVar(&c.KubeClientBurst, "kube-client-burst", c.KubeClientBurst, "Sets the burst on the app "+
+		"kubernetes client, this will configure throttling on requests sent to the apiserver"+
+		"(If not set, it will use client default ones)")
+
 	return c
 }
 

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -59,6 +59,14 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 				}
 			}
 
+			// Set client throttling settings for Kubernetes clients.
+			if opts.Client.KubeClientBurst > 0 {
+				restConfig.Burst = opts.Client.KubeClientBurst
+			}
+			if opts.Client.KubeClientQPS > 0 {
+				restConfig.QPS = opts.Client.KubeClientQPS
+			}
+
 			// Initialise token reviewer if enabled
 			var tokenReviewer *tokenreview.TokenReview
 			if opts.App.TokenPassthrough.Enabled {


### PR DESCRIPTION
More context on this other PR: #50

This PR instead of settings safe usable defaults, lets you configure it using 2 flags:

- `--kube-client-qps`.
- `--kube-client-burst`.
