### PR TITLE
Add mTLS support to OIDC issuer

### DIFF
--- a/cmd/app/options/oidc.go
+++ b/cmd/app/options/oidc.go
@@ -4,6 +4,8 @@ package options
 import (
 	"fmt"
 
+	"k8s.io/apiserver/pkg/server/options"
+
 	"github.com/spf13/pflag"
 
 	cliflag "k8s.io/component-base/cli/flag"
@@ -19,6 +21,7 @@ type OIDCAuthenticationOptions struct {
 	GroupsPrefix   string
 	SigningAlgs    []string
 	RequiredClaims map[string]string
+	ClientCertKey  options.CertKey
 }
 
 func NewOIDCAuthenticationOptions(nfs *cliflag.NamedFlagSets) *OIDCAuthenticationOptions {
@@ -26,8 +29,17 @@ func NewOIDCAuthenticationOptions(nfs *cliflag.NamedFlagSets) *OIDCAuthenticatio
 }
 
 func (o *OIDCAuthenticationOptions) Validate() error {
-	if o != nil && (len(o.IssuerURL) > 0) != (len(o.ClientID) > 0) {
+	if o == nil {
+		return nil
+	}
+
+	if (len(o.IssuerURL) > 0) != (len(o.ClientID) > 0) {
 		return fmt.Errorf("oidc-issuer-url and oidc-client-id should be specified together")
+	}
+
+	if ((o.ClientCertKey.CertFile != "") && (o.ClientCertKey.KeyFile == "")) ||
+		(o.ClientCertKey.CertFile == "" && o.ClientCertKey.KeyFile != "") {
+		return fmt.Errorf("oidc-tls-client-cert-file and oidc-tls-client-cert-key must be specified together")
 	}
 
 	return nil
@@ -60,6 +72,14 @@ func (o *OIDCAuthenticationOptions) AddFlags(fs *pflag.FlagSet) *OIDCAuthenticat
 	fs.StringVar(&o.GroupsPrefix, "oidc-groups-prefix", "", ""+
 		"If provided, all groups will be prefixed with this value to prevent conflicts with "+
 		"other authentication strategies.")
+
+	fs.StringVar(&o.ClientCertKey.CertFile, "oidc-tls-client-cert-file", "", ""+
+		"The absolute path to a X.509 client certificate. If provided, HTTPS requests made to the OIDC issuer will "+
+		"use mTLS.  Also requires --oidc-tls-client-key-file.")
+
+	fs.StringVar(&o.ClientCertKey.KeyFile, "oidc-tls-client-key-file", "", ""+
+		"The absolute path to a X.509 private key. If provided, HTTPS requests made to the OIDC issuer will use mTLS."+
+		"Also requires --oidc-tls-client-cert-file.")
 
 	fs.StringSliceVar(&o.SigningAlgs, "oidc-signing-algs", []string{"RS256"}, ""+
 		"Comma-separated list of allowed JOSE asymmetric signing algorithms. JWTs with a "+

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/jstemmer/go-junit-report v1.0.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/jstemmer/go-junit-report v1.0.0 h1:8X1gzZpR+nVQLAht+L/foqOeX2l9DTZoaIPbEQHxsds=
+github.com/jstemmer/go-junit-report v1.0.0/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/test/e2e/suite/cases/doc.go
+++ b/test/e2e/suite/cases/doc.go
@@ -5,6 +5,7 @@ import (
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/audit"
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/headers"
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/impersonation"
+	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/mtls"
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/passthrough"
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/probe"
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/rbac"

--- a/test/e2e/suite/cases/mtls/mtls.go
+++ b/test/e2e/suite/cases/mtls/mtls.go
@@ -1,0 +1,119 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package probe
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/jetstack/kube-oidc-proxy/test/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
+	"github.com/jetstack/kube-oidc-proxy/test/kind"
+)
+
+var _ = framework.CasesDescribe("mTLS", func() {
+	f := framework.NewDefaultFramework("mtls")
+
+	It("Should become ready if the issuer accepts our client certificate", func() {
+		// Create a new cert/key bundle that can be used as a TLS client
+		clientBundle, err := util.NewTLSSelfSignedCertKey("proxy-oidc-client", []net.IP{net.ParseIP("127.0.0.1")}, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Set up a secret to hold the new certificate/key pair
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oidc-client",
+				Namespace: f.Namespace.Name,
+			},
+			Data: map[string][]byte{
+				"tls.crt": clientBundle.CertBytes,
+				"tls.key": clientBundle.KeyBytes,
+			},
+		}
+
+		By("Creating a secret to hold the OIDC client certificate/key pair")
+		_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Since this is a self-signed certificate pass it to the issuers as our "CA".
+		volume := corev1.Volume{
+			Name: "oidc-client",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "oidc-client",
+				},
+			},
+		}
+
+		// Re-deploy the Issuer with the --tls-client-ca-file argument which will force certs to be required and to be
+		// validated to the certificate provided in that file.  Since we've self-signed our own then we just pass it
+		// here as well.
+		f.DeployIssuerWith([]corev1.Volume{volume}, "--tls-client-ca-file=/oidc-client/tls.crt")
+
+		// Re-deploy the Proxy with the same volume so that it can use it to find its OIDC client TLS cert/key.
+		f.DeployProxyWith([]corev1.Volume{volume},
+			"--oidc-tls-client-cert-file=/oidc-client/tls.crt",
+			"--oidc-tls-client-key-file=/oidc-client/tls.key")
+
+		err = f.Helper().WaitForDeploymentReady(f.Namespace.Name, kind.ProxyImageName, time.Second*5)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Should not become ready if the issuer rejects our client certificate", func() {
+		// Create a new cert/key bundle that can be used as a TLS client
+		clientBundle, err := util.NewTLSSelfSignedCertKey("proxy-oidc-client", []net.IP{net.ParseIP("127.0.0.1")}, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Set up a secret to hold the new certificate/key pair
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oidc-client",
+				Namespace: f.Namespace.Name,
+			},
+			Data: map[string][]byte{
+				"tls.crt": clientBundle.CertBytes,
+				"tls.key": clientBundle.KeyBytes,
+			},
+		}
+
+		By("Creating a secret to hold the OIDC client certificate/key pair")
+		_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Since this is a self-signed certificate pass it to the issuers as our "CA".
+		volume := corev1.Volume{
+			Name: "oidc-client",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "oidc-client",
+				},
+			},
+		}
+
+		// Re-deploy the Issuer with the --tls-client-ca-file argument which will force certs to be required and to be
+		// validated to the certificate provided in that file.  Since we've self-signed our own then we just pass it
+		// here as the CA certificate.
+		f.DeployIssuerWith([]corev1.Volume{volume}, "--tls-client-ca-file=/oidc-client/tls.crt")
+
+		// Re-deploy the Proxy without specifying the TLS client arguments.  This should prevent it from becoming ready
+		// since we won't be able to initialize the issuer.
+		By("Deleting and re-deploying kube-oidc-proxy deployment")
+		err = f.Helper().DeleteProxy(f.Namespace.Name)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = f.Helper().WaitForDeploymentToDelete(f.Namespace.Name, kind.ProxyImageName, time.Second*30)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Re-deploying kube-oidc-proxy")
+		_, _, err = f.Helper().DeployProxy(f.Namespace, f.IssuerURL(),
+			f.ClientID(), f.IssuerKeyBundle(), nil)
+		// Error should occur (not ready)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/test/environment/dev/dev.go
+++ b/test/environment/dev/dev.go
@@ -98,7 +98,7 @@ func deploy() {
 
 	fmt.Printf("> created new namespace %s\n", ns.Name)
 
-	issuerKeyBundle, issuerURL, err := helper.DeployIssuer(ns.Name)
+	issuerKeyBundle, issuerURL, err := helper.DeployIssuer(ns.Name, nil)
 	errExit(err)
 
 	fmt.Printf("> deployed issuer at url %s\n", issuerURL)

--- a/test/tools/issuer/Dockerfile
+++ b/test/tools/issuer/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Jetstack Ltd. See LICENSE for details.
 FROM alpine:3.10
 
-LABEL description="A basic OIDC issuer that prsents a well-known and certs endpoint."
+LABEL description="A basic OIDC issuer that presents a well-known and certs endpoint."
 
 RUN apk --no-cache add ca-certificates
 

--- a/test/tools/issuer/cmd/main.go
+++ b/test/tools/issuer/cmd/main.go
@@ -21,7 +21,7 @@ func main() {
 		Short: "A very basic OIDC issuer to present a well-known endpoint.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			iss, err := issuer.New(opts.IssuerURL, opts.KeyFile, opts.CertFile, stopCh)
+			iss, err := issuer.New(opts.IssuerURL, opts.KeyFile, opts.CertFile, opts.ClientCACertFile, stopCh)
 			if err != nil {
 				return err
 			}

--- a/test/tools/issuer/cmd/options/options.go
+++ b/test/tools/issuer/cmd/options/options.go
@@ -11,8 +11,9 @@ type Options struct {
 
 	IssuerURL string
 
-	KeyFile  string
-	CertFile string
+	KeyFile          string
+	CertFile         string
+	ClientCACertFile string
 }
 
 func (o *Options) AddFlags(cmd *cobra.Command) {
@@ -34,6 +35,9 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&o.CertFile, "tls-cert-file",
 		"/etc/oidc/key.pem", "File location to certificate for serving.")
 	o.must(cmd.MarkPersistentFlagRequired("tls-cert-file"))
+
+	cmd.PersistentFlags().StringVar(&o.ClientCACertFile, "tls-client-ca-file",
+		"", "File location to the CA bundle to verify client certificates.")
 }
 
 func (o *Options) must(err error) {


### PR DESCRIPTION
This adds command line options that allow supplying a client certificate to be used when connecting to the OIDC issuer.  The client certificate must be signed by a CA that the OIDC issuer trusts.  This allows interoperability with OIDC issuers that enforce mTLS on sessions.

Issue: #67