### PR TITLE
Fix forbidden because of `userextras/authentication.kubernetes.io/credential-id`

### DIFF
--- a/deploy/charts/kube-oidc-proxy/templates/clusterrole.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/clusterrole.yaml
@@ -20,6 +20,7 @@ rules:
   - "userextras/remote-client-ip"
   - "tokenreviews"
   # to support end user impersonation
+  - "userextras/authentication.kubernetes.io/credential-id"
   - "userextras/originaluser.jetstack.io-user"
   - "userextras/originaluser.jetstack.io-groups"
   - "userextras/originaluser.jetstack.io-extra"


### PR DESCRIPTION
Fixes #71 