### PR TITLE
feat: multi-issuer OIDC support

### DIFF
--- a/.github/workflows/oidc.yaml
+++ b/.github/workflows/oidc.yaml
@@ -1,0 +1,19 @@
+name: mint-oidc-token
+on: workflow_dispatch
+permissions:
+  id-token: write
+jobs:
+  mint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v7
+      with:
+        script: |
+          const core = require('@actions/core');
+          const t = await core.getIDToken('kube-oidc-proxy-kind-test')
+          require('fs').writeFileSync('token.jwt', t)
+    - uses: actions/upload-artifact@v4
+      with:
+        name: oidc-token
+        path: token.jwt
+        retention-days: 1

--- a/.github/workflows/oidc.yaml
+++ b/.github/workflows/oidc.yaml
@@ -9,7 +9,6 @@ jobs:
     - uses: actions/github-script@v7
       with:
         script: |
-          const core = require('@actions/core');
           const t = await core.getIDToken('kube-oidc-proxy-kind-test')
           require('fs').writeFileSync('token.jwt', t)
     - uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+**enhancements:**
+ - Multi-issuer OIDC authentication via --authentication-config (AuthenticationConfiguration v1/v1beta1), based on [\#85](https://github.com/TremoloSecurity/kube-oidc-proxy/pull/85) with strict versioned config loading, whole-document validation, a shared CEL compiler and configurable readiness (--readiness-require-all-issuers)
+
 # 1.0.12
 **tasks:**
  - 1.0.12 build [\#83](https://github.com/TremoloSecurity/kube-oidc-proxy/issues/83)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ users:
 ```
 
 ## Configuration
+ - [Multi-issuer OIDC authentication](./docs/tasks/multi-issuer.md)
  - [Token Passthrough](./docs/tasks/token-passthrough.md)
  - [No Impersonation](./docs/tasks/no-impersonation.md)
  - [Extra Impersonations Headers](./docs/tasks/extra-impersonation-headers.md)

--- a/cmd/app/options/app.go
+++ b/cmd/app/options/app.go
@@ -14,6 +14,8 @@ type KubeOIDCProxyOptions struct {
 	DisableImpersonation bool
 	ReadinessProbePort   int
 
+	ReadinessRequireAllIssuers bool
+
 	FlushInterval time.Duration
 
 	ExtraHeaderOptions ExtraHeaderOptions
@@ -42,6 +44,13 @@ func (k *KubeOIDCProxyOptions) AddFlags(fs *pflag.FlagSet) *KubeOIDCProxyOptions
 
 	fs.IntVarP(&k.ReadinessProbePort, "readiness-probe-port", "P", 8080,
 		"Port to expose readiness probe.")
+
+	fs.BoolVar(&k.ReadinessRequireAllIssuers, "readiness-require-all-issuers", false,
+		"If true, the readiness probe reports ready only once every issuer in the "+
+			"authentication configuration has been initialized (JWKS fetched). If false "+
+			"(default), the proxy reports ready as soon as at least one issuer is "+
+			"initialized; issuers still pending are logged and keep initializing in "+
+			"the background. Configuration errors always fail startup regardless.")
 
 	fs.DurationVar(&k.FlushInterval, "flush-interval", time.Millisecond*50,
 		"Specifies the interval to flush request bodies. If 0ms, "+

--- a/cmd/app/options/authentication_config.go
+++ b/cmd/app/options/authentication_config.go
@@ -6,11 +6,23 @@ import (
 	"os"
 
 	"github.com/spf13/pflag"
-	"sigs.k8s.io/yaml"
-
-	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	apiserver "k8s.io/apiserver/pkg/apis/apiserver"
+	"k8s.io/apiserver/pkg/apis/apiserver/install"
+	"k8s.io/apiserver/pkg/apis/apiserver/validation"
+	authenticationcel "k8s.io/apiserver/pkg/authentication/cel"
 	cliflag "k8s.io/component-base/cli/flag"
 )
+
+var (
+	authConfigScheme = runtime.NewScheme()
+	authConfigCodecs = serializer.NewCodecFactory(authConfigScheme, serializer.EnableStrict)
+)
+
+func init() {
+	install.Install(authConfigScheme)
+}
 
 type AuthenticationConfigOptions struct {
 	ConfigFile string
@@ -22,8 +34,9 @@ func NewAuthenticationConfigOptions(nfs *cliflag.NamedFlagSets) *AuthenticationC
 
 func (o *AuthenticationConfigOptions) AddFlags(fs *pflag.FlagSet) *AuthenticationConfigOptions {
 	fs.StringVar(&o.ConfigFile, "authentication-config", o.ConfigFile,
-		"Path to a file containing an AuthenticationConfiguration (apiserver.config.k8s.io/v1beta1). "+
-			"This flag is mutually exclusive with the --oidc-* flags.")
+		"Path to a file containing an AuthenticationConfiguration "+
+			"(apiserver.config.k8s.io/v1 or v1beta1) enabling multi-issuer OIDC "+
+			"authentication. This flag is mutually exclusive with the --oidc-* flags.")
 	return o
 }
 
@@ -37,17 +50,39 @@ func (o *AuthenticationConfigOptions) Validate() error {
 	return nil
 }
 
-func (o *AuthenticationConfigOptions) Load() (*apiserverv1beta1.AuthenticationConfiguration, error) {
+// Load reads, strictly decodes (v1 or v1beta1), converts to the internal
+// type and validates the whole AuthenticationConfiguration document.
+// Validation compiles every CEL expression with the given compiler and
+// rejects duplicate issuers across entries.
+func (o *AuthenticationConfigOptions) Load(compiler authenticationcel.Compiler) (*apiserver.AuthenticationConfiguration, error) {
 	data, err := os.ReadFile(o.ConfigFile)
 	if err != nil {
 		return nil, fmt.Errorf("reading authentication-config %q: %w", o.ConfigFile, err)
 	}
-	var cfg apiserverv1beta1.AuthenticationConfiguration
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+
+	obj, gvk, err := authConfigCodecs.UniversalDecoder().Decode(data, nil, nil)
+	if err != nil {
 		return nil, fmt.Errorf("parsing authentication-config %q: %w", o.ConfigFile, err)
 	}
+
+	cfg, ok := obj.(*apiserver.AuthenticationConfiguration)
+	if !ok {
+		return nil, fmt.Errorf("authentication-config %q: expected AuthenticationConfiguration, got %s", o.ConfigFile, gvk)
+	}
+
+	if cfg.Anonymous != nil {
+		return nil, fmt.Errorf("authentication-config %q: the 'anonymous' section is not supported by kube-oidc-proxy", o.ConfigFile)
+	}
+
 	if len(cfg.JWT) == 0 {
 		return nil, fmt.Errorf("authentication-config %q: jwt list must not be empty", o.ConfigFile)
 	}
-	return &cfg, nil
+
+	// disallowedIssuers is nil: that parameter exists for kube-apiserver to
+	// reserve its own service-account issuer, which does not apply to the proxy.
+	if errs := validation.ValidateAuthenticationConfiguration(compiler, cfg, nil).ToAggregate(); errs != nil {
+		return nil, fmt.Errorf("invalid authentication-config %q: %w", o.ConfigFile, errs)
+	}
+
+	return cfg, nil
 }

--- a/cmd/app/options/authentication_config.go
+++ b/cmd/app/options/authentication_config.go
@@ -1,0 +1,53 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package options
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+	"sigs.k8s.io/yaml"
+
+	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
+	cliflag "k8s.io/component-base/cli/flag"
+)
+
+type AuthenticationConfigOptions struct {
+	ConfigFile string
+}
+
+func NewAuthenticationConfigOptions(nfs *cliflag.NamedFlagSets) *AuthenticationConfigOptions {
+	return new(AuthenticationConfigOptions).AddFlags(nfs.FlagSet("Authentication Config"))
+}
+
+func (o *AuthenticationConfigOptions) AddFlags(fs *pflag.FlagSet) *AuthenticationConfigOptions {
+	fs.StringVar(&o.ConfigFile, "authentication-config", o.ConfigFile,
+		"Path to a file containing an AuthenticationConfiguration (apiserver.config.k8s.io/v1beta1). "+
+			"This flag is mutually exclusive with the --oidc-* flags.")
+	return o
+}
+
+func (o *AuthenticationConfigOptions) Validate() error {
+	if o.ConfigFile == "" {
+		return nil
+	}
+	if _, err := os.Stat(o.ConfigFile); err != nil {
+		return fmt.Errorf("authentication-config file %q: %w", o.ConfigFile, err)
+	}
+	return nil
+}
+
+func (o *AuthenticationConfigOptions) Load() (*apiserverv1beta1.AuthenticationConfiguration, error) {
+	data, err := os.ReadFile(o.ConfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading authentication-config %q: %w", o.ConfigFile, err)
+	}
+	var cfg apiserverv1beta1.AuthenticationConfiguration
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing authentication-config %q: %w", o.ConfigFile, err)
+	}
+	if len(cfg.JWT) == 0 {
+		return nil, fmt.Errorf("authentication-config %q: jwt list must not be empty", o.ConfigFile)
+	}
+	return &cfg, nil
+}

--- a/cmd/app/options/authentication_config_test.go
+++ b/cmd/app/options/authentication_config_test.go
@@ -4,131 +4,189 @@ package options
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	authenticationcel "k8s.io/apiserver/pkg/authentication/cel"
 )
 
-func writeFile(t *testing.T, content string) string {
+func writeAuthConfig(t *testing.T, content string) string {
 	t.Helper()
-	f, err := os.CreateTemp(t.TempDir(), "auth-config-*.yaml")
-	if err != nil {
-		t.Fatalf("creating temp file: %v", err)
+	path := filepath.Join(t.TempDir(), "auth.yaml")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
 	}
-	if _, err := f.WriteString(content); err != nil {
-		t.Fatalf("writing temp file: %v", err)
-	}
-	if err := f.Close(); err != nil {
-		t.Fatalf("closing temp file: %v", err)
-	}
-	return f.Name()
+	return path
 }
 
-func TestAuthenticationConfigOptions_Validate(t *testing.T) {
-	existingFile := writeFile(t, "")
-
-	tests := map[string]struct {
-		configFile string
-		wantErr    bool
-	}{
-		"empty config file is valid (flag not set)": {
-			configFile: "",
-			wantErr:    false,
-		},
-		"existing file is valid": {
-			configFile: existingFile,
-			wantErr:    false,
-		},
-		"non-existent file is an error": {
-			configFile: filepath.Join(t.TempDir(), "does-not-exist.yaml"),
-			wantErr:    true,
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			o := &AuthenticationConfigOptions{ConfigFile: tc.configFile}
-			err := o.Validate()
-			if (err != nil) != tc.wantErr {
-				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
-			}
-		})
-	}
-}
-
-func TestAuthenticationConfigOptions_Load(t *testing.T) {
-	validConfig := `
-apiVersion: apiserver.config.k8s.io/v1beta1
+const validV1Config = `apiVersion: apiserver.config.k8s.io/v1
 kind: AuthenticationConfiguration
 jwt:
-  - issuer:
-      url: https://vault.example.com/v1/identity/oidc
-      audiences:
-        - my-client
-    claimMappings:
-      username:
-        claim: email
-        prefix: ""
-      groups:
-        claim: groups
-        prefix: ""
-  - issuer:
-      url: https://issuer2.example.com/v1/identity/oidc
-      audiences:
-        - kubernetes
-    claimMappings:
-      username:
-        claim: email
-        prefix: ""
-      groups:
-        claim: groups
-        prefix: ""
+- issuer:
+    url: https://issuer1.example.com
+    audiences: ["aud-one"]
+  claimMappings:
+    username:
+      claim: sub
+      prefix: "one:"
+    groups:
+      expression: '["g:" + claims.owner]'
+  claimValidationRules:
+  - expression: 'claims.owner == "my-org"'
+    message: "only my-org"
+- issuer:
+    url: https://issuer2.example.com
+    audiences: ["aud-two"]
+  claimMappings:
+    username:
+      claim: sub
+      prefix: "two:"
 `
 
-	tests := map[string]struct {
-		content    string
-		wantErr    bool
-		wantJWTLen int
+const validV1Beta1Config = `apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthenticationConfiguration
+jwt:
+- issuer:
+    url: https://issuer1.example.com
+    audiences: ["aud-one"]
+  claimMappings:
+    username:
+      claim: sub
+      prefix: "one:"
+`
+
+func TestAuthenticationConfigLoad(t *testing.T) {
+	compiler := authenticationcel.NewDefaultCompiler()
+
+	tests := []struct {
+		name        string
+		config      string
+		wantErr     string // substring; empty means expect success
+		wantIssuers int
 	}{
-		"valid config with two issuers": {
-			content:    validConfig,
-			wantJWTLen: 2,
+		{
+			name:        "valid v1 with CEL mappings and validation rules",
+			config:      validV1Config,
+			wantIssuers: 2,
 		},
-		"invalid YAML": {
-			content: "not: valid: yaml: [",
-			wantErr: true,
+		{
+			name:        "valid v1beta1",
+			config:      validV1Beta1Config,
+			wantIssuers: 1,
 		},
-		"empty JWT list is an error": {
-			content: `
-apiVersion: apiserver.config.k8s.io/v1beta1
+		{
+			name: "wrong kind rejected",
+			config: `apiVersion: apiserver.config.k8s.io/v1
+kind: AuthorizationConfiguration
+authorizers: []
+`,
+			wantErr: "expected AuthenticationConfiguration",
+		},
+		{
+			name: "unknown field rejected (strict decoding)",
+			config: `apiVersion: apiserver.config.k8s.io/v1
+kind: AuthenticationConfiguration
+jwt:
+- issuer:
+    url: https://issuer1.example.com
+    audiencess: ["typo"]
+  claimMappings:
+    username:
+      claim: sub
+      prefix: "one:"
+`,
+			wantErr: "unknown field",
+		},
+		{
+			name: "duplicate issuer URLs rejected",
+			config: `apiVersion: apiserver.config.k8s.io/v1
+kind: AuthenticationConfiguration
+jwt:
+- issuer:
+    url: https://issuer1.example.com
+    audiences: ["aud-one"]
+  claimMappings:
+    username:
+      claim: sub
+      prefix: "one:"
+- issuer:
+    url: https://issuer1.example.com
+    audiences: ["aud-two"]
+  claimMappings:
+    username:
+      claim: sub
+      prefix: "two:"
+`,
+			wantErr: "Duplicate value",
+		},
+		{
+			name: "invalid CEL expression rejected",
+			config: `apiVersion: apiserver.config.k8s.io/v1
+kind: AuthenticationConfiguration
+jwt:
+- issuer:
+    url: https://issuer1.example.com
+    audiences: ["aud-one"]
+  claimMappings:
+    username:
+      expression: 'claims.'
+`,
+			wantErr: "compilation failed",
+		},
+		{
+			name: "anonymous section rejected",
+			config: `apiVersion: apiserver.config.k8s.io/v1
+kind: AuthenticationConfiguration
+anonymous:
+  enabled: true
+jwt:
+- issuer:
+    url: https://issuer1.example.com
+    audiences: ["aud-one"]
+  claimMappings:
+    username:
+      claim: sub
+      prefix: "one:"
+`,
+			wantErr: "not supported",
+		},
+		{
+			name: "empty jwt list rejected",
+			config: `apiVersion: apiserver.config.k8s.io/v1
 kind: AuthenticationConfiguration
 jwt: []
 `,
-			wantErr: true,
+			wantErr: "must not be empty",
 		},
 	}
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			path := writeFile(t, tc.content)
-			o := &AuthenticationConfigOptions{ConfigFile: path}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &AuthenticationConfigOptions{ConfigFile: writeAuthConfig(t, tc.config)}
+			cfg, err := opts.Load(compiler)
 
-			cfg, err := o.Load()
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("Load() error = %v, wantErr %v", err, tc.wantErr)
-			}
-			if tc.wantErr {
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
+				}
 				return
 			}
-			if got := len(cfg.JWT); got != tc.wantJWTLen {
-				t.Errorf("Load() JWT count = %d, want %d", got, tc.wantJWTLen)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(cfg.JWT) != tc.wantIssuers {
+				t.Fatalf("expected %d issuers, got %d", tc.wantIssuers, len(cfg.JWT))
 			}
 		})
 	}
 }
 
-func TestAuthenticationConfigOptions_Load_FileNotFound(t *testing.T) {
-	o := &AuthenticationConfigOptions{ConfigFile: "/does/not/exist.yaml"}
-	_, err := o.Load()
-	if err == nil {
-		t.Error("Load() expected error for missing file, got nil")
+func TestAuthenticationConfigLoadMissingFile(t *testing.T) {
+	opts := &AuthenticationConfigOptions{ConfigFile: "/does/not/exist.yaml"}
+	if _, err := opts.Load(authenticationcel.NewDefaultCompiler()); err == nil {
+		t.Fatal("expected error for missing file, got nil")
 	}
 }

--- a/cmd/app/options/authentication_config_test.go
+++ b/cmd/app/options/authentication_config_test.go
@@ -1,0 +1,134 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package options
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "auth-config-*.yaml")
+	if err != nil {
+		t.Fatalf("creating temp file: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("writing temp file: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("closing temp file: %v", err)
+	}
+	return f.Name()
+}
+
+func TestAuthenticationConfigOptions_Validate(t *testing.T) {
+	existingFile := writeFile(t, "")
+
+	tests := map[string]struct {
+		configFile string
+		wantErr    bool
+	}{
+		"empty config file is valid (flag not set)": {
+			configFile: "",
+			wantErr:    false,
+		},
+		"existing file is valid": {
+			configFile: existingFile,
+			wantErr:    false,
+		},
+		"non-existent file is an error": {
+			configFile: filepath.Join(t.TempDir(), "does-not-exist.yaml"),
+			wantErr:    true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			o := &AuthenticationConfigOptions{ConfigFile: tc.configFile}
+			err := o.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestAuthenticationConfigOptions_Load(t *testing.T) {
+	validConfig := `
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthenticationConfiguration
+jwt:
+  - issuer:
+      url: https://vault.example.com/v1/identity/oidc
+      audiences:
+        - my-client
+    claimMappings:
+      username:
+        claim: email
+        prefix: ""
+      groups:
+        claim: groups
+        prefix: ""
+  - issuer:
+      url: https://issuer2.example.com/v1/identity/oidc
+      audiences:
+        - kubernetes
+    claimMappings:
+      username:
+        claim: email
+        prefix: ""
+      groups:
+        claim: groups
+        prefix: ""
+`
+
+	tests := map[string]struct {
+		content    string
+		wantErr    bool
+		wantJWTLen int
+	}{
+		"valid config with two issuers": {
+			content:    validConfig,
+			wantJWTLen: 2,
+		},
+		"invalid YAML": {
+			content: "not: valid: yaml: [",
+			wantErr: true,
+		},
+		"empty JWT list is an error": {
+			content: `
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthenticationConfiguration
+jwt: []
+`,
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := writeFile(t, tc.content)
+			o := &AuthenticationConfigOptions{ConfigFile: path}
+
+			cfg, err := o.Load()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Load() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if got := len(cfg.JWT); got != tc.wantJWTLen {
+				t.Errorf("Load() JWT count = %d, want %d", got, tc.wantJWTLen)
+			}
+		})
+	}
+}
+
+func TestAuthenticationConfigOptions_Load_FileNotFound(t *testing.T) {
+	o := &AuthenticationConfigOptions{ConfigFile: "/does/not/exist.yaml"}
+	_, err := o.Load()
+	if err == nil {
+		t.Error("Load() expected error for missing file, got nil")
+	}
+}

--- a/cmd/app/options/oidc.go
+++ b/cmd/app/options/oidc.go
@@ -25,11 +25,16 @@ func NewOIDCAuthenticationOptions(nfs *cliflag.NamedFlagSets) *OIDCAuthenticatio
 	return new(OIDCAuthenticationOptions).AddFlags(nfs.FlagSet("OIDC"))
 }
 
-func (o *OIDCAuthenticationOptions) Validate() error {
+// Validate checks the OIDC options. This flag is mutually exclusive with --authentication-config:
+// when authConfigSet is true, --oidc-* flags must not be set (enforced by Options.Validate)
+// and their individual validation is skipped.
+func (o *OIDCAuthenticationOptions) Validate(authConfigSet bool) error {
+	if authConfigSet {
+		return nil
+	}
 	if o != nil && (len(o.IssuerURL) > 0) != (len(o.ClientID) > 0) {
 		return fmt.Errorf("oidc-issuer-url and oidc-client-id should be specified together")
 	}
-
 	return nil
 }
 

--- a/cmd/app/options/oidc_test.go
+++ b/cmd/app/options/oidc_test.go
@@ -1,0 +1,55 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package options
+
+import "testing"
+
+func TestOIDCAuthenticationOptions_Validate(t *testing.T) {
+	tests := map[string]struct {
+		issuerURL     string
+		clientID      string
+		authConfigSet bool
+		wantErr       bool
+	}{
+		"both issuer URL and client ID set is valid": {
+			issuerURL: "https://vault.example.com",
+			clientID:  "my-client",
+			wantErr:   false,
+		},
+		"neither issuer URL nor client ID set is valid": {
+			wantErr: false,
+		},
+		"issuer URL without client ID is an error": {
+			issuerURL: "https://vault.example.com",
+			wantErr:   true,
+		},
+		"client ID without issuer URL is an error": {
+			clientID: "my-client",
+			wantErr:  true,
+		},
+		"missing flags are ignored when authentication-config is set": {
+			issuerURL:     "",
+			clientID:      "",
+			authConfigSet: true,
+			wantErr:       false,
+		},
+		"mismatched flags are ignored when authentication-config is set": {
+			issuerURL:     "https://vault.example.com",
+			clientID:      "",
+			authConfigSet: true,
+			wantErr:       false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			o := &OIDCAuthenticationOptions{
+				IssuerURL: tc.issuerURL,
+				ClientID:  tc.clientID,
+			}
+			err := o.Validate(tc.authConfigSet)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -17,12 +17,13 @@ const (
 )
 
 type Options struct {
-	App                *KubeOIDCProxyOptions
-	OIDCAuthentication *OIDCAuthenticationOptions
-	SecureServing      *SecureServingOptions
-	Audit              *AuditOptions
-	Client             *ClientOptions
-	Misc               *MiscOptions
+	App                  *KubeOIDCProxyOptions
+	OIDCAuthentication   *OIDCAuthenticationOptions
+	AuthenticationConfig *AuthenticationConfigOptions
+	SecureServing        *SecureServingOptions
+	Audit                *AuditOptions
+	Client               *ClientOptions
+	Misc                 *MiscOptions
 
 	nfs *cliflag.NamedFlagSets
 }
@@ -32,12 +33,13 @@ func New() *Options {
 
 	// Add flags to command sets
 	return &Options{
-		App:                NewKubeOIDCProxyOptions(nfs),
-		OIDCAuthentication: NewOIDCAuthenticationOptions(nfs),
-		SecureServing:      NewSecureServingOptions(nfs),
-		Audit:              NewAuditOptions(nfs),
-		Client:             NewClientOptions(nfs),
-		Misc:               NewMiscOptions(nfs),
+		App:                  NewKubeOIDCProxyOptions(nfs),
+		OIDCAuthentication:   NewOIDCAuthenticationOptions(nfs),
+		AuthenticationConfig: NewAuthenticationConfigOptions(nfs),
+		SecureServing:        NewSecureServingOptions(nfs),
+		Audit:                NewAuditOptions(nfs),
+		Client:               NewClientOptions(nfs),
+		Misc:                 NewMiscOptions(nfs),
 
 		nfs: nfs,
 	}
@@ -71,7 +73,17 @@ func (o *Options) Validate(cmd *cobra.Command) error {
 
 	var errs []error
 
-	if err := o.OIDCAuthentication.Validate(); err != nil {
+	if err := o.AuthenticationConfig.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	authConfigSet := o.AuthenticationConfig.ConfigFile != ""
+
+	if authConfigSet && oidcFlagsChanged(cmd) {
+		errs = append(errs, fmt.Errorf("authentication-config and --oidc-* flags are mutually exclusive"))
+	}
+
+	if err := o.OIDCAuthentication.Validate(authConfigSet); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -97,4 +109,25 @@ func (o *Options) Validate(cmd *cobra.Command) error {
 	}
 
 	return nil
+}
+
+var oidcFlagNames = []string{
+	"oidc-issuer-url",
+	"oidc-client-id",
+	"oidc-ca-file",
+	"oidc-username-claim",
+	"oidc-username-prefix",
+	"oidc-groups-claim",
+	"oidc-groups-prefix",
+	"oidc-signing-algs",
+	"oidc-required-claim",
+}
+
+func oidcFlagsChanged(cmd *cobra.Command) bool {
+	for _, name := range oidcFlagNames {
+		if f := cmd.Flag(name); f != nil && f.Changed {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/app/options/options_test.go
+++ b/cmd/app/options/options_test.go
@@ -1,0 +1,106 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package options
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestOidcFlagsChanged(t *testing.T) {
+	tests := map[string]struct {
+		changedFlags []string
+		want         bool
+	}{
+		"no flags changed": {
+			want: false,
+		},
+		"oidc-issuer-url changed": {
+			changedFlags: []string{"oidc-issuer-url"},
+			want:         true,
+		},
+		"oidc-signing-algs changed": {
+			changedFlags: []string{"oidc-signing-algs"},
+			want:         true,
+		},
+		"non-oidc flag changed": {
+			changedFlags: []string{"secure-port"},
+			want:         false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().String("oidc-issuer-url", "", "")
+			cmd.Flags().String("oidc-client-id", "", "")
+			cmd.Flags().String("oidc-ca-file", "", "")
+			cmd.Flags().String("oidc-username-claim", "", "")
+			cmd.Flags().String("oidc-username-prefix", "", "")
+			cmd.Flags().String("oidc-groups-claim", "", "")
+			cmd.Flags().String("oidc-groups-prefix", "", "")
+			cmd.Flags().StringSlice("oidc-signing-algs", nil, "")
+			cmd.Flags().String("oidc-required-claim", "", "")
+			cmd.Flags().String("secure-port", "", "")
+
+			for _, name := range tc.changedFlags {
+				if err := cmd.Flags().Set(name, "value"); err != nil {
+					t.Fatalf("setting flag %q: %v", name, err)
+				}
+			}
+
+			if got := oidcFlagsChanged(cmd); got != tc.want {
+				t.Errorf("oidcFlagsChanged() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidate_MutualExclusivity(t *testing.T) {
+	tests := map[string]struct {
+		configFile    string
+		changedFlags  []string
+		wantErrSubstr string
+	}{
+		"both authentication-config and oidc-issuer-url is an error": {
+			configFile:    "/some/path",
+			changedFlags:  []string{"oidc-issuer-url"},
+			wantErrSubstr: "mutually exclusive",
+		},
+		"both authentication-config and oidc-ca-file is an error": {
+			configFile:    "/some/path",
+			changedFlags:  []string{"oidc-ca-file"},
+			wantErrSubstr: "mutually exclusive",
+		},
+		"authentication-config without oidc flags is not a mutual exclusivity error": {
+			configFile: "/some/path",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			o := New()
+			cmd := &cobra.Command{}
+			o.AddFlags(cmd)
+
+			o.AuthenticationConfig.ConfigFile = tc.configFile
+			for _, flagName := range tc.changedFlags {
+				if err := cmd.Flags().Set(flagName, "https://issuer.example.com"); err != nil {
+					t.Fatalf("setting flag %q: %v", flagName, err)
+				}
+			}
+
+			err := o.Validate(cmd)
+			if tc.wantErrSubstr == "" {
+				if err != nil && strings.Contains(err.Error(), "mutually exclusive") {
+					t.Errorf("Validate() unexpected mutual exclusivity error: %v", err)
+				}
+			} else {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrSubstr) {
+					t.Errorf("Validate() error = %v, want error containing %q", err, tc.wantErrSubstr)
+				}
+			}
+		})
+	}
+}

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -2,12 +2,22 @@
 package app
 
 import (
+	"context"
+	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/spf13/cobra"
+	apiserverapi "k8s.io/apiserver/pkg/apis/apiserver"
+	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	tokenunion "k8s.io/apiserver/pkg/authentication/token/union"
 	"k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
+	"k8s.io/apiserver/plugin/pkg/authenticator/token/oidc"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 
 	"github.com/jetstack/kube-oidc-proxy/cmd/app/options"
 	"github.com/jetstack/kube-oidc-proxy/pkg/probe"
@@ -100,27 +110,35 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 			}
 
 			subectAccessReviewer, err := subjectaccessreview.New(kubeclient.AuthorizationV1().SubjectAccessReviews())
-
 			if err != nil {
 				return err
 			}
 
-			// Initialise proxy with OIDC token authenticator
-			p, err := proxy.New(restConfig, opts.OIDCAuthentication, opts.Audit,
+			tokenAuther, issuerURLs, err := buildTokenAuther(opts)
+			if err != nil {
+				return err
+			}
+
+			// Initialise proxy with token authenticator
+			p, err := proxy.New(restConfig, tokenAuther, opts.Audit,
 				tokenReviewer, subectAccessReviewer, secureServingInfo, proxyConfig)
 			if err != nil {
 				return err
 			}
 
-			// Create a fake JWT to set up readiness probe
-			fakeJWT, err := util.FakeJWT(opts.OIDCAuthentication.IssuerURL)
-			if err != nil {
-				return err
+			// Build a fake JWT per issuer for the readiness probe.
+			fakeJWTs := make([]string, 0, len(issuerURLs))
+			for _, issuerURL := range issuerURLs {
+				fakeJWT, err := util.FakeJWT(issuerURL)
+				if err != nil {
+					return err
+				}
+				fakeJWTs = append(fakeJWTs, fakeJWT)
 			}
 
 			// Start readiness probe
 			if err := probe.Run(strconv.Itoa(opts.App.ReadinessProbePort),
-				fakeJWT, p.OIDCTokenAuthenticator()); err != nil {
+				fakeJWTs, p.OIDCTokenAuthenticator()); err != nil {
 				return err
 			}
 
@@ -140,4 +158,105 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 			return nil
 		},
 	}
+}
+
+// caFromFile implements oidc.CAContentProvider backed by a PEM file.
+type caFromFile struct {
+	path string
+}
+
+func (c caFromFile) CurrentCABundleContent() []byte {
+	data, err := os.ReadFile(c.path)
+	if err != nil {
+		klog.Errorf("failed to read CA file %q: %v", c.path, err)
+	}
+	return data
+}
+
+// caContentProvider returns the CAContentProvider to use for a given path.
+// When path is empty it returns nil, signalling oidc.New() to use the system certificate pool.
+func caContentProvider(path string) oidc.CAContentProvider {
+	if path == "" {
+		return nil
+	}
+	return caFromFile{path: path}
+}
+
+func buildTokenAuther(opts *options.Options) (authenticator.Token, []string, error) {
+	if opts.AuthenticationConfig.ConfigFile != "" {
+		return buildUnionAuther(opts)
+	}
+	return buildSingleAuther(caFromFile{path: opts.OIDCAuthentication.CAFile}, opts.OIDCAuthentication)
+}
+
+func buildSingleAuther(ca caFromFile, o *options.OIDCAuthenticationOptions) (authenticator.Token, []string, error) {
+	usernamePrefix := o.UsernamePrefix
+	groupsPrefix := o.GroupsPrefix
+	jwtConfig := apiserverapi.JWTAuthenticator{
+		Issuer: apiserverapi.Issuer{
+			URL:       o.IssuerURL,
+			Audiences: []string{o.ClientID},
+		},
+		ClaimMappings: apiserverapi.ClaimMappings{
+			Username: apiserverapi.PrefixedClaimOrExpression{
+				Claim:  o.UsernameClaim,
+				Prefix: &usernamePrefix,
+			},
+			Groups: apiserverapi.PrefixedClaimOrExpression{
+				Claim:  o.GroupsClaim,
+				Prefix: &groupsPrefix,
+			},
+		},
+	}
+	auther, err := oidc.New(context.Background(), oidc.Options{
+		CAContentProvider:    caContentProvider(ca.path),
+		SupportedSigningAlgs: o.SigningAlgs,
+		JWTAuthenticator:     jwtConfig,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating OIDC authenticator for issuer %q: %w", o.IssuerURL, err)
+	}
+	return auther, []string{o.IssuerURL}, nil
+}
+
+func buildUnionAuther(opts *options.Options) (authenticator.Token, []string, error) {
+	authCfg, err := opts.AuthenticationConfig.Load()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	authers := make([]authenticator.Token, 0, len(authCfg.JWT))
+	issuerURLs := make([]string, 0, len(authCfg.JWT))
+	for _, jwtEntry := range authCfg.JWT {
+		auther, err := oidcAutherFromJWT(jwtEntry, oidc.AllValidSigningAlgorithms())
+		if err != nil {
+			return nil, nil, fmt.Errorf("building authenticator for issuer %q: %w", jwtEntry.Issuer.URL, err)
+		}
+		authers = append(authers, auther)
+		issuerURLs = append(issuerURLs, jwtEntry.Issuer.URL)
+	}
+
+	return tokenunion.NewFailOnError(authers...), issuerURLs, nil
+}
+
+func oidcAutherFromJWT(entry apiserverv1beta1.JWTAuthenticator, signingAlgs []string) (authenticator.Token, error) {
+	var jwtConfig apiserverapi.JWTAuthenticator
+	if err := apiserverv1beta1.Convert_v1beta1_JWTAuthenticator_To_apiserver_JWTAuthenticator(&entry, &jwtConfig, nil); err != nil {
+		return nil, fmt.Errorf("converting JWT authenticator for issuer %q: %w", entry.Issuer.URL, err)
+	}
+
+	var provider oidc.CAContentProvider
+	if entry.Issuer.CertificateAuthority != "" {
+		var err error
+		provider, err = dynamiccertificates.NewStaticCAContent("oidc-authenticator", []byte(entry.Issuer.CertificateAuthority))
+		if err != nil {
+			return nil, fmt.Errorf("invalid certificateAuthority for issuer %q: %w", entry.Issuer.URL, err)
+		}
+	}
+
+	return oidc.New(context.Background(), oidc.Options{
+		CAContentProvider:    provider,
+		SupportedSigningAlgs: signingAlgs,
+		JWTAuthenticator:     jwtConfig,
+	})
 }

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 	apiserverapi "k8s.io/apiserver/pkg/apis/apiserver"
-	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+	authenticationcel "k8s.io/apiserver/pkg/authentication/cel"
 	tokenunion "k8s.io/apiserver/pkg/authentication/token/union"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
@@ -220,7 +220,11 @@ func buildSingleAuther(ca caFromFile, o *options.OIDCAuthenticationOptions) (aut
 }
 
 func buildUnionAuther(opts *options.Options) (authenticator.Token, []string, error) {
-	authCfg, err := opts.AuthenticationConfig.Load()
+	// One CEL compiler shared by document validation and every authenticator:
+	// CEL environments are expensive to construct.
+	compiler := authenticationcel.NewDefaultCompiler()
+
+	authCfg, err := opts.AuthenticationConfig.Load(compiler)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -228,7 +232,7 @@ func buildUnionAuther(opts *options.Options) (authenticator.Token, []string, err
 	authers := make([]authenticator.Token, 0, len(authCfg.JWT))
 	issuerURLs := make([]string, 0, len(authCfg.JWT))
 	for _, jwtEntry := range authCfg.JWT {
-		auther, err := oidcAutherFromJWT(jwtEntry, oidc.AllValidSigningAlgorithms())
+		auther, err := oidcAutherFromJWT(jwtEntry, compiler, oidc.AllValidSigningAlgorithms())
 		if err != nil {
 			return nil, nil, fmt.Errorf("building authenticator for issuer %q: %w", jwtEntry.Issuer.URL, err)
 		}
@@ -236,21 +240,18 @@ func buildUnionAuther(opts *options.Options) (authenticator.Token, []string, err
 		issuerURLs = append(issuerURLs, jwtEntry.Issuer.URL)
 	}
 
+	klog.Infof("configured OIDC issuers: %v", issuerURLs)
+
 	return tokenunion.NewFailOnError(authers...), issuerURLs, nil
 }
 
-func oidcAutherFromJWT(entry apiserverv1beta1.JWTAuthenticator, signingAlgs []string) (authenticator.Token, error) {
-	var jwtConfig apiserverapi.JWTAuthenticator
-	if err := apiserverv1beta1.Convert_v1beta1_JWTAuthenticator_To_apiserver_JWTAuthenticator(&entry, &jwtConfig, nil); err != nil {
-		return nil, fmt.Errorf("converting JWT authenticator for issuer %q: %w", entry.Issuer.URL, err)
-	}
-
+func oidcAutherFromJWT(jwtConfig apiserverapi.JWTAuthenticator, compiler authenticationcel.Compiler, signingAlgs []string) (authenticator.Token, error) {
 	var provider oidc.CAContentProvider
-	if entry.Issuer.CertificateAuthority != "" {
+	if jwtConfig.Issuer.CertificateAuthority != "" {
 		var err error
-		provider, err = dynamiccertificates.NewStaticCAContent("oidc-authenticator", []byte(entry.Issuer.CertificateAuthority))
+		provider, err = dynamiccertificates.NewStaticCAContent("oidc-authenticator", []byte(jwtConfig.Issuer.CertificateAuthority))
 		if err != nil {
-			return nil, fmt.Errorf("invalid certificateAuthority for issuer %q: %w", entry.Issuer.URL, err)
+			return nil, fmt.Errorf("invalid certificateAuthority for issuer %q: %w", jwtConfig.Issuer.URL, err)
 		}
 	}
 
@@ -258,5 +259,6 @@ func oidcAutherFromJWT(entry apiserverv1beta1.JWTAuthenticator, signingAlgs []st
 		CAContentProvider:    provider,
 		SupportedSigningAlgs: signingAlgs,
 		JWTAuthenticator:     jwtConfig,
+		Compiler:             compiler,
 	})
 }

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -190,10 +190,10 @@ func buildTokenAuther(opts *options.Options) (authenticator.Token, []string, err
 	if opts.AuthenticationConfig.ConfigFile != "" {
 		return buildUnionAuther(opts)
 	}
-	return buildSingleAuther(caFromFile{path: opts.OIDCAuthentication.CAFile}, opts.OIDCAuthentication)
+	return buildSingleAuther(opts.OIDCAuthentication)
 }
 
-func buildSingleAuther(ca caFromFile, o *options.OIDCAuthenticationOptions) (authenticator.Token, []string, error) {
+func buildSingleAuther(o *options.OIDCAuthenticationOptions) (authenticator.Token, []string, error) {
 	usernamePrefix := o.UsernamePrefix
 	groupsPrefix := o.GroupsPrefix
 	jwtConfig := apiserverapi.JWTAuthenticator{
@@ -213,7 +213,7 @@ func buildSingleAuther(ca caFromFile, o *options.OIDCAuthenticationOptions) (aut
 		},
 	}
 	auther, err := oidc.New(context.Background(), oidc.Options{
-		CAContentProvider:    caContentProvider(ca.path),
+		CAContentProvider:    caContentProvider(o.CAFile),
 		SupportedSigningAlgs: o.SigningAlgs,
 		JWTAuthenticator:     jwtConfig,
 	})

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -126,19 +126,23 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 				return err
 			}
 
-			// Build a fake JWT per issuer for the readiness probe.
-			fakeJWTs := make([]string, 0, len(issuerURLs))
+			// Build a per-issuer readiness probe entry.
+			issuerProbes := make([]probe.IssuerReadiness, 0, len(issuerURLs))
 			for _, issuerURL := range issuerURLs {
 				fakeJWT, err := util.FakeJWT(issuerURL)
 				if err != nil {
 					return err
 				}
-				fakeJWTs = append(fakeJWTs, fakeJWT)
+				issuerProbes = append(issuerProbes, probe.IssuerReadiness{
+					IssuerURL: issuerURL,
+					FakeJWT:   fakeJWT,
+				})
 			}
 
 			// Start readiness probe
 			if err := probe.Run(strconv.Itoa(opts.App.ReadinessProbePort),
-				fakeJWTs, p.OIDCTokenAuthenticator()); err != nil {
+				issuerProbes, opts.App.ReadinessRequireAllIssuers,
+				p.OIDCTokenAuthenticator()); err != nil {
 				return err
 			}
 

--- a/cmd/app/run_test.go
+++ b/cmd/app/run_test.go
@@ -3,9 +3,12 @@ package app
 
 import (
 	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
-	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
+	apiserverapi "k8s.io/apiserver/pkg/apis/apiserver"
+	authenticationcel "k8s.io/apiserver/pkg/authentication/cel"
 
 	"github.com/jetstack/kube-oidc-proxy/cmd/app/options"
 )
@@ -27,27 +30,27 @@ func writeTempFile(t *testing.T, content string) string {
 
 func TestOIDCAutherFromJWT_Construction(t *testing.T) {
 	emptyPrefix := ""
-	entry := apiserverv1beta1.JWTAuthenticator{
-		Issuer: apiserverv1beta1.Issuer{
+	entry := apiserverapi.JWTAuthenticator{
+		Issuer: apiserverapi.Issuer{
 			URL:       "https://vault.example.com/v1/identity/oidc",
 			Audiences: []string{"my-client"},
 		},
-		ClaimMappings: apiserverv1beta1.ClaimMappings{
-			Username: apiserverv1beta1.PrefixedClaimOrExpression{
+		ClaimMappings: apiserverapi.ClaimMappings{
+			Username: apiserverapi.PrefixedClaimOrExpression{
 				Claim:  "email",
 				Prefix: &emptyPrefix,
 			},
-			Groups: apiserverv1beta1.PrefixedClaimOrExpression{
+			Groups: apiserverapi.PrefixedClaimOrExpression{
 				Claim:  "groups",
 				Prefix: &emptyPrefix,
 			},
 		},
-		UserValidationRules: []apiserverv1beta1.UserValidationRule{
+		UserValidationRules: []apiserverapi.UserValidationRule{
 			{Expression: "!user.username.startsWith('system:')", Message: "no system: prefix"},
 		},
 	}
 
-	auther, err := oidcAutherFromJWT(entry, []string{"RS256"})
+	auther, err := oidcAutherFromJWT(entry, authenticationcel.NewDefaultCompiler(), []string{"RS256"})
 	if err != nil {
 		t.Fatalf("oidcAutherFromJWT() unexpected error: %v", err)
 	}
@@ -137,6 +140,48 @@ jwt:
 		if issuerURLs[i] != want[i] {
 			t.Errorf("buildTokenAuther() issuerURLs[%d] = %q, want %q", i, issuerURLs[i], want[i])
 		}
+	}
+}
+
+func TestBuildUnionAutherFromV1ConfigWithCEL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth.yaml")
+	cfg := `apiVersion: apiserver.config.k8s.io/v1
+kind: AuthenticationConfiguration
+jwt:
+- issuer:
+    url: https://issuer1.example.com
+    audiences: ["aud-one"]
+  claimMappings:
+    username:
+      claim: sub
+      prefix: "one:"
+    groups:
+      expression: '["g:" + claims.owner]'
+- issuer:
+    url: https://issuer2.example.com
+    audiences: ["aud-two"]
+  claimMappings:
+    username:
+      claim: sub
+      prefix: "two:"
+`
+	if err := os.WriteFile(path, []byte(cfg), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := options.New()
+	opts.AuthenticationConfig.ConfigFile = path
+
+	auther, issuerURLs, err := buildTokenAuther(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if auther == nil {
+		t.Fatal("expected a token authenticator, got nil")
+	}
+	want := []string{"https://issuer1.example.com", "https://issuer2.example.com"}
+	if !reflect.DeepEqual(issuerURLs, want) {
+		t.Fatalf("expected issuer URLs %v, got %v", want, issuerURLs)
 	}
 }
 

--- a/cmd/app/run_test.go
+++ b/cmd/app/run_test.go
@@ -1,0 +1,153 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package app
+
+import (
+	"os"
+	"testing"
+
+	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
+
+	"github.com/jetstack/kube-oidc-proxy/cmd/app/options"
+)
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "auth-config-*.yaml")
+	if err != nil {
+		t.Fatalf("creating temp file: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("writing temp file: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("closing temp file: %v", err)
+	}
+	return f.Name()
+}
+
+func TestOIDCAutherFromJWT_Construction(t *testing.T) {
+	emptyPrefix := ""
+	entry := apiserverv1beta1.JWTAuthenticator{
+		Issuer: apiserverv1beta1.Issuer{
+			URL:       "https://vault.example.com/v1/identity/oidc",
+			Audiences: []string{"my-client"},
+		},
+		ClaimMappings: apiserverv1beta1.ClaimMappings{
+			Username: apiserverv1beta1.PrefixedClaimOrExpression{
+				Claim:  "email",
+				Prefix: &emptyPrefix,
+			},
+			Groups: apiserverv1beta1.PrefixedClaimOrExpression{
+				Claim:  "groups",
+				Prefix: &emptyPrefix,
+			},
+		},
+		UserValidationRules: []apiserverv1beta1.UserValidationRule{
+			{Expression: "!user.username.startsWith('system:')", Message: "no system: prefix"},
+		},
+	}
+
+	auther, err := oidcAutherFromJWT(entry, []string{"RS256"})
+	if err != nil {
+		t.Fatalf("oidcAutherFromJWT() unexpected error: %v", err)
+	}
+	if auther == nil {
+		t.Error("oidcAutherFromJWT() returned nil authenticator")
+	}
+}
+
+func TestBuildTokenAuther_SingleIssuer(t *testing.T) {
+	opts := &options.Options{
+		OIDCAuthentication: &options.OIDCAuthenticationOptions{
+			IssuerURL:     "https://vault.example.com/v1/identity/oidc",
+			ClientID:      "my-client",
+			UsernameClaim: "email",
+			GroupsClaim:   "groups",
+			SigningAlgs:   []string{"RS256"},
+		},
+		AuthenticationConfig: &options.AuthenticationConfigOptions{},
+	}
+
+	auther, issuerURLs, err := buildTokenAuther(opts)
+	if err != nil {
+		t.Fatalf("buildTokenAuther() unexpected error: %v", err)
+	}
+	if auther == nil {
+		t.Error("buildTokenAuther() returned nil authenticator")
+	}
+	if want := []string{opts.OIDCAuthentication.IssuerURL}; len(issuerURLs) != len(want) || issuerURLs[0] != want[0] {
+		t.Errorf("buildTokenAuther() issuerURLs = %v, want %v", issuerURLs, want)
+	}
+}
+
+func TestBuildTokenAuther_AuthConfig(t *testing.T) {
+	configContent := `
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthenticationConfiguration
+jwt:
+  - issuer:
+      url: https://vault.example.com/v1/identity/oidc
+      audiences:
+        - my-client
+    claimMappings:
+      username:
+        claim: email
+        prefix: ""
+      groups:
+        claim: groups
+        prefix: ""
+  - issuer:
+      url: https://issuer2.example.com/v1/identity/oidc
+      audiences:
+        - kubernetes
+    claimMappings:
+      username:
+        claim: email
+        prefix: ""
+      groups:
+        claim: groups
+        prefix: ""
+`
+	configPath := writeTempFile(t, configContent)
+
+	opts := &options.Options{
+		OIDCAuthentication: &options.OIDCAuthenticationOptions{
+			SigningAlgs: []string{"RS256"},
+		},
+		AuthenticationConfig: &options.AuthenticationConfigOptions{
+			ConfigFile: configPath,
+		},
+	}
+
+	auther, issuerURLs, err := buildTokenAuther(opts)
+	if err != nil {
+		t.Fatalf("buildTokenAuther() unexpected error: %v", err)
+	}
+	if auther == nil {
+		t.Error("buildTokenAuther() returned nil authenticator")
+	}
+	want := []string{
+		"https://vault.example.com/v1/identity/oidc",
+		"https://issuer2.example.com/v1/identity/oidc",
+	}
+	if len(issuerURLs) != len(want) {
+		t.Fatalf("buildTokenAuther() issuerURLs = %v, want %v", issuerURLs, want)
+	}
+	for i := range want {
+		if issuerURLs[i] != want[i] {
+			t.Errorf("buildTokenAuther() issuerURLs[%d] = %q, want %q", i, issuerURLs[i], want[i])
+		}
+	}
+}
+
+func TestBuildTokenAuther_AuthConfig_InvalidFile(t *testing.T) {
+	opts := &options.Options{
+		OIDCAuthentication:   &options.OIDCAuthenticationOptions{SigningAlgs: []string{"RS256"}},
+		AuthenticationConfig: &options.AuthenticationConfigOptions{ConfigFile: "/does/not/exist.yaml"},
+	}
+
+	_, _, err := buildTokenAuther(opts)
+	if err == nil {
+		t.Error("buildTokenAuther() expected error for missing config file, got nil")
+	}
+}

--- a/deploy/charts/kube-oidc-proxy/templates/deployment.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/deployment.yaml
@@ -56,13 +56,13 @@ spec:
           {{- if .Values.readinessRequireAllIssuers }}
           - "--readiness-require-all-issuers"
           {{- end }}
-          {{- if .Values.oidc.usernamePrefix }}
+          {{- if and .Values.oidc.usernamePrefix (not .Values.authenticationConfig.content) }}
           - "--oidc-username-prefix=$(OIDC_USERNAME_PREFIX)"
           {{ end }}
-          {{- if .Values.oidc.groupsClaim }}
+          {{- if and .Values.oidc.groupsClaim (not .Values.authenticationConfig.content) }}
           - "--oidc-groups-claim=$(OIDC_GROUPS_CLAIM)"
           {{ end }}
-          {{- if .Values.oidc.groupsPrefix }}
+          {{- if and .Values.oidc.groupsPrefix (not .Values.authenticationConfig.content) }}
           - "--oidc-groups-prefix=$(OIDC_GROUPS_PREFIX)"
           {{ end }}
           {{- if and .Values.oidc.signingAlgs (not .Values.authenticationConfig.content) }}
@@ -106,21 +106,21 @@ spec:
               name: {{ include "kube-oidc-proxy.fullname" . }}-config
               key: oidc.username-claim
         {{- end }}
-        {{- if .Values.oidc.usernamePrefix }}
+        {{- if and .Values.oidc.usernamePrefix (not .Values.authenticationConfig.content) }}
         - name: OIDC_USERNAME_PREFIX
           valueFrom:
             secretKeyRef:
               name: {{ include "kube-oidc-proxy.fullname" . }}-config
               key: oidc.username-prefix
         {{ end }}
-        {{- if .Values.oidc.groupsClaim }}
+        {{- if and .Values.oidc.groupsClaim (not .Values.authenticationConfig.content) }}
         - name: OIDC_GROUPS_CLAIM
           valueFrom:
             secretKeyRef:
               name: {{ include "kube-oidc-proxy.fullname" . }}-config
               key: oidc.groups-claim
         {{ end }}
-        {{- if .Values.oidc.groupsPrefix }}
+        {{- if and .Values.oidc.groupsPrefix (not .Values.authenticationConfig.content) }}
         - name: OIDC_GROUPS_PREFIX
           valueFrom:
             secretKeyRef:

--- a/deploy/charts/kube-oidc-proxy/templates/deployment.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
   {{ end }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret_config.yaml") . | sha256sum }}
       labels:
         app.kubernetes.io/name: {{ include "kube-oidc-proxy.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -50,6 +52,9 @@ spec:
           {{- if .Values.oidc.caPEM }}
           - "--oidc-ca-file=/etc/oidc/oidc-ca.pem"
           {{- end }}
+          {{- end }}
+          {{- if .Values.readinessRequireAllIssuers }}
+          - "--readiness-require-all-issuers"
           {{- end }}
           {{- if .Values.oidc.usernamePrefix }}
           - "--oidc-username-prefix=$(OIDC_USERNAME_PREFIX)"

--- a/deploy/charts/kube-oidc-proxy/templates/deployment.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/deployment.yaml
@@ -41,12 +41,16 @@ spec:
           - "--secure-port=8443"
           - "--tls-cert-file=/etc/oidc/tls/crt.pem"
           - "--tls-private-key-file=/etc/oidc/tls/key.pem"
+          {{- if .Values.authenticationConfig.content }}
+          - "--authentication-config=/etc/oidc/authentication-config.yaml"
+          {{- else }}
           - "--oidc-client-id=$(OIDC_CLIENT_ID)"
           - "--oidc-issuer-url=$(OIDC_ISSUER_URL)"
           - "--oidc-username-claim=$(OIDC_USERNAME_CLAIM)"
           {{- if .Values.oidc.caPEM }}
           - "--oidc-ca-file=/etc/oidc/oidc-ca.pem"
-          {{ end }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.oidc.usernamePrefix }}
           - "--oidc-username-prefix=$(OIDC_USERNAME_PREFIX)"
           {{ end }}
@@ -56,7 +60,7 @@ spec:
           {{- if .Values.oidc.groupsPrefix }}
           - "--oidc-groups-prefix=$(OIDC_GROUPS_PREFIX)"
           {{ end }}
-          {{- if .Values.oidc.signingAlgs }}
+          {{- if and .Values.oidc.signingAlgs (not .Values.authenticationConfig.content) }}
           - "--oidc-signing-algs=$(OIDC_SIGNING_ALGS)"
           {{ end }}
           {{- if .Values.oidc.requiredClaims }}
@@ -80,6 +84,7 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         env:
+        {{- if not .Values.authenticationConfig.content }}
         - name: OIDC_CLIENT_ID
           valueFrom:
             secretKeyRef:
@@ -95,6 +100,7 @@ spec:
             secretKeyRef:
               name: {{ include "kube-oidc-proxy.fullname" . }}-config
               key: oidc.username-claim
+        {{- end }}
         {{- if .Values.oidc.usernamePrefix }}
         - name: OIDC_USERNAME_PREFIX
           valueFrom:
@@ -116,7 +122,7 @@ spec:
               name: {{ include "kube-oidc-proxy.fullname" . }}-config
               key: oidc.groups-prefix
         {{ end }}
-        {{- if .Values.oidc.signingAlgs }}
+        {{- if and .Values.oidc.signingAlgs (not .Values.authenticationConfig.content) }}
         - name: OIDC_SIGNING_ALGS
           valueFrom:
             secretKeyRef:
@@ -131,24 +137,30 @@ spec:
               key: oidc.required-claims
         {{ end }}
         volumeMounts:
-          {{- if .Values.oidc.caPEM }}
+          {{- if or .Values.oidc.caPEM .Values.authenticationConfig.content }}
           - name: kube-oidc-proxy-config
             mountPath: /etc/oidc
             readOnly: true
-          {{ end }}
+          {{- end }}
           - name: kube-oidc-proxy-tls
             mountPath: /etc/oidc/tls
             readOnly: true
           {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 10 }}{{ end }}
       volumes:
-        {{ if .Values.oidc.caPEM }}
+        {{- if or .Values.oidc.caPEM .Values.authenticationConfig.content }}
         - name: kube-oidc-proxy-config
           secret:
             secretName: {{ include "kube-oidc-proxy.fullname" . }}-config
             items:
+            {{- if .Values.oidc.caPEM }}
             - key: oidc.ca-pem
               path: oidc-ca.pem
-        {{ end }}
+            {{- end }}
+            {{- if .Values.authenticationConfig.content }}
+            - key: authentication-config.yaml
+              path: authentication-config.yaml
+            {{- end }}
+        {{- end }}
         {{- if .Values.extraVolumes }}{{ toYaml .Values.extraVolumes | trim | nindent 8 }}{{ end }}
         - name: kube-oidc-proxy-tls
           secret:

--- a/deploy/charts/kube-oidc-proxy/templates/secret_config.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/secret_config.yaml
@@ -41,3 +41,7 @@ data:
   {{- if .Values.oidc.requiredClaims }}
   oidc.required-claims: {{ include "requiredClaims" . | b64enc }}
   {{- end }}
+
+  {{- if .Values.authenticationConfig.content }}
+  authentication-config.yaml: {{ .Values.authenticationConfig.content | b64enc }}
+  {{- end }}

--- a/deploy/charts/kube-oidc-proxy/values.yaml
+++ b/deploy/charts/kube-oidc-proxy/values.yaml
@@ -39,13 +39,14 @@ tls:
 # working.
 oidc:
   # A minimal configuration requires setting clientId, issuerUrl and usernameClaim
-  # values.
+  # values. Not required when authenticationConfig.content is set.
   clientId: ""
   issuerUrl: ""
   usernameClaim: ""
 
   # PEM encoded value of CA cert that will verify TLS connection to
   # OIDC issuer URL. If not provided, default hosts root CA's will be used.
+  # Not used when authenticationConfig.content is set (CA is inline in the config).
   caPEM:
 
   usernamePrefix:
@@ -55,6 +56,16 @@ oidc:
   signingAlgs:
     - RS256
   requiredClaims: {}
+
+# Multi-issuer OIDC authentication via AuthenticationConfiguration file
+# (apiserver.config.k8s.io/v1beta1). Mutually exclusive with oidc.issuerUrl,
+# oidc.clientId, and oidc.usernameClaim. When set, each issuer's CA must be
+# specified inline in the configuration file under issuer.certificateAuthority.
+authenticationConfig:
+  # YAML content of an AuthenticationConfiguration resource.
+  # When non-empty, --authentication-config is passed to the proxy and the
+  # individual --oidc-* flags are omitted.
+  content: ""
 
 # To enable token passthrough feature
 # https://github.com/jetstack/kube-oidc-proxy/blob/master/docs/tasks/token-passthrough.md

--- a/deploy/charts/kube-oidc-proxy/values.yaml
+++ b/deploy/charts/kube-oidc-proxy/values.yaml
@@ -58,9 +58,11 @@ oidc:
   requiredClaims: {}
 
 # Multi-issuer OIDC authentication via AuthenticationConfiguration file
-# (apiserver.config.k8s.io/v1 or v1beta1). Mutually exclusive with oidc.issuerUrl,
-# oidc.clientId, and oidc.usernameClaim. When set, each issuer's CA must be
-# specified inline in the configuration file under issuer.certificateAuthority.
+# (apiserver.config.k8s.io/v1 or v1beta1). Mutually exclusive with ALL oidc.*
+# fields (issuerUrl, clientId, usernameClaim, caPEM, usernamePrefix,
+# groupsClaim, groupsPrefix, signingAlgs, requiredClaims). When set, each
+# issuer's CA must be specified inline in the configuration file under
+# issuer.certificateAuthority.
 authenticationConfig:
   # YAML content of an AuthenticationConfiguration resource.
   # When non-empty, --authentication-config is passed to the proxy and the

--- a/deploy/charts/kube-oidc-proxy/values.yaml
+++ b/deploy/charts/kube-oidc-proxy/values.yaml
@@ -58,7 +58,7 @@ oidc:
   requiredClaims: {}
 
 # Multi-issuer OIDC authentication via AuthenticationConfiguration file
-# (apiserver.config.k8s.io/v1beta1). Mutually exclusive with oidc.issuerUrl,
+# (apiserver.config.k8s.io/v1 or v1beta1). Mutually exclusive with oidc.issuerUrl,
 # oidc.clientId, and oidc.usernameClaim. When set, each issuer's CA must be
 # specified inline in the configuration file under issuer.certificateAuthority.
 authenticationConfig:
@@ -66,6 +66,12 @@ authenticationConfig:
   # When non-empty, --authentication-config is passed to the proxy and the
   # individual --oidc-* flags are omitted.
   content: ""
+
+# If true, the readiness probe waits for every issuer in
+# authenticationConfig.content to initialize (JWKS fetched) before the pod
+# reports ready. Default false: ready once at least one issuer initializes,
+# so a single IdP outage cannot block a rollout for all other systems.
+readinessRequireAllIssuers: false
 
 # To enable token passthrough feature
 # https://github.com/jetstack/kube-oidc-proxy/blob/master/docs/tasks/token-passthrough.md

--- a/docs/tasks/multi-issuer.md
+++ b/docs/tasks/multi-issuer.md
@@ -1,0 +1,131 @@
+# Multi-Issuer OIDC Authentication
+
+kube-oidc-proxy can accept JWTs from several OIDC issuers at once using the
+standard Kubernetes [Structured Authentication Configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration)
+file format — the same format kube-apiserver consumes since Kubernetes 1.30.
+This is particularly useful on managed clusters (EKS, GKE, DOKS, ...) where
+apiserver flags cannot be changed and only a single (or no) native OIDC
+provider can be configured.
+
+## Enabling
+
+Pass `--authentication-config=/path/to/config.yaml`. This flag is mutually
+exclusive with all `--oidc-*` flags. Both `apiserver.config.k8s.io/v1` and
+`v1beta1` are accepted; the file is strictly validated at startup (unknown
+fields, duplicate issuers, and invalid CEL expressions are rejected). Only
+the `jwt:` section is supported; `anonymous:` is rejected.
+
+The file is read once at startup. To apply changes, restart the pods — the
+Helm chart annotates the Deployment with a config checksum, so editing
+`authenticationConfig.content` triggers a rolling restart automatically.
+
+## Example: GitHub Actions + internal issuer + GitLab
+
+```yaml
+apiVersion: apiserver.config.k8s.io/v1
+kind: AuthenticationConfiguration
+jwt:
+# GitHub Actions: no usable groups claim, so CEL synthesizes groups.
+- issuer:
+    url: https://token.actions.githubusercontent.com
+    audiences: ["kube-oidc-proxy.example.com"]
+  claimMappings:
+    username:
+      claim: sub
+      prefix: "gha:"
+    groups:
+      expression: '["github:" + claims.repository_owner]'
+  claimValidationRules:
+  - expression: 'claims.repository_owner == "my-org"'
+    message: "only my-org tokens are accepted"
+# Internal issuer with a private CA and a real groups array claim.
+- issuer:
+    url: https://auth.internal.example.com
+    audiences: ["kubernetes"]
+    certificateAuthority: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+  claimMappings:
+    username: {claim: sub, prefix: "sys-a:"}
+    groups:   {claim: groups, prefix: "sys-a:"}
+# GitLab CI: username and groups built with CEL.
+- issuer:
+    url: https://gitlab.example.com
+    audiences: ["kube-oidc-proxy.example.com"]
+  claimMappings:
+    username:
+      expression: '"gitlab:" + claims.project_path'
+    groups:
+      expression: '["gitlab:ns:" + claims.namespace_path]'
+```
+
+RBAC then binds the prefixed identities:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gha-platform-iac-main
+subjects:
+- kind: User
+  name: "gha:repo:my-org/platform-iac:ref:refs/heads/main"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: edit
+  apiGroup: rbac.authorization.k8s.io
+```
+
+## Security: always use distinct per-issuer prefixes
+
+All issuers feed the same RBAC namespace. Without distinct prefixes, issuer
+B could mint a `sub` or group value that collides with an identity you bound
+for issuer A. Give every issuer a unique `prefix:` (or bake a unique prefix
+into every CEL expression) and never use `prefix: "-"`-style unprefixed
+usernames in a multi-issuer setup.
+
+## Readiness
+
+By default the pod reports ready once at least one issuer's JWKS has been
+fetched; issuers still pending are logged and keep initializing in the
+background (tokens for them fail with 401 until initialized). Set
+`--readiness-require-all-issuers` (Helm: `readinessRequireAllIssuers: true`)
+to only report ready when every issuer is initialized. Configuration errors
+(invalid YAML, unknown fields, duplicate issuers, bad CEL) always fail
+startup, regardless of this flag.
+
+## Helm
+
+```yaml
+authenticationConfig:
+  content: |
+    apiVersion: apiserver.config.k8s.io/v1
+    kind: AuthenticationConfiguration
+    jwt:
+    - issuer:
+        url: https://token.actions.githubusercontent.com
+        audiences: ["kube-oidc-proxy.example.com"]
+      claimMappings:
+        username:
+          claim: sub
+          prefix: "gha:"
+        groups:
+          expression: '["github:" + claims.repository_owner]'
+    - issuer:
+        url: https://auth.internal.example.com
+        audiences: ["kubernetes"]
+      claimMappings:
+        username: {claim: sub, prefix: "sys-a:"}
+        groups:   {claim: groups, prefix: "sys-a:"}
+readinessRequireAllIssuers: false
+```
+
+## Notes
+
+- Signing algorithms: with `--authentication-config`, all valid JOSE signing
+  algorithms are accepted (matching kube-apiserver); `--oidc-signing-algs`
+  applies only to the single-issuer flag mode.
+- Issuer JWKS endpoints must be reachable from the proxy pod network (not
+  from the control plane), so private internal issuers work.
+- Each issuer entry may carry its own `certificateAuthority` inline.

--- a/docs/tasks/multi-issuer.md
+++ b/docs/tasks/multi-issuer.md
@@ -19,13 +19,21 @@ The file is read once at startup. To apply changes, restart the pods — the
 Helm chart annotates the Deployment with a config checksum, so editing
 `authenticationConfig.content` triggers a rolling restart automatically.
 
-## Example: GitHub Actions + internal issuer + GitLab
+## Examples
+
+Each recipe below is one entry for the `jwt:` list — combine them freely in
+a single configuration. Every issuer must use its own distinct username and
+groups prefix (see [Security](#security-always-use-distinct-per-issuer-prefixes)).
+
+### GitHub Actions
+
+GitHub Actions tokens carry no groups claim, so CEL synthesizes one from
+`repository_owner`. Note that newer GitHub `sub` claims embed numeric IDs
+(`repo:Owner@<owner_id>/repo@<repo_id>:ref:...`) — decode a real token before
+writing bindings, or use the CEL username alternative for a stable, readable
+identity.
 
 ```yaml
-apiVersion: apiserver.config.k8s.io/v1
-kind: AuthenticationConfiguration
-jwt:
-# GitHub Actions: no usable groups claim, so CEL synthesizes groups.
 - issuer:
     url: https://token.actions.githubusercontent.com
     audiences: ["kube-oidc-proxy.example.com"]
@@ -33,12 +41,130 @@ jwt:
     username:
       claim: sub
       prefix: "gha:"
+    # Alternative: readable username independent of GitHub's sub format:
+    # username:
+    #   expression: '"gha:" + claims.repository + ":" + claims.ref'
     groups:
       expression: '["github:" + claims.repository_owner]'
   claimValidationRules:
   - expression: 'claims.repository_owner == "my-org"'
     message: "only my-org tokens are accepted"
-# Internal issuer with a private CA and a real groups array claim.
+  # Recommended hardening: pin numeric IDs so a recycled repo/owner name
+  # cannot inherit access:
+  # - expression: 'claims.repository_owner_id == "1234567"'
+  #   message: "token not issued for the expected account"
+```
+
+Workflow side: `permissions: id-token: write`, then
+`core.getIDToken('kube-oidc-proxy.example.com')` (actions/github-script) —
+the audience argument must match `audiences` above.
+
+### TeamCity ([teamcity-oidc-jwt](https://github.com/JetBrains/teamcity-oidc-jwt) plugin)
+
+The plugin serves unauthenticated discovery/JWKS under
+`<server>/app/oidc-jwt/.well-known/...`. Its raw `sub` is an internal ID
+chain (`_Root:project31:bt32`); the external-ID claims make far better
+identities:
+
+```yaml
+- issuer:
+    url: https://teamcity.example.com/app/oidc-jwt
+    audiences: ["kube-oidc-proxy.example.com"]
+    # certificateAuthority: |     # inline CA if TeamCity uses a private cert
+    #   -----BEGIN CERTIFICATE-----
+    #   ...
+    #   -----END CERTIFICATE-----
+  claimMappings:
+    username:
+      # one identity per build configuration, e.g. "tc:MyProject_Deploy"
+      expression: '"tc:" + claims.build_type_external_id'
+    groups:
+      # bind whole TeamCity projects at once
+      expression: '["tc-project:" + claims.project_external_id]'
+  claimValidationRules:
+  # only default-branch builds may authenticate (drop for branch builds):
+  - expression: 'claims.branch_is_default == true'
+    message: "only default-branch TeamCity builds may authenticate"
+```
+
+Build side: enable the plugin's *Build Parameters* feature with the audience
+configured — the token arrives as `env.TEAMCITY_BUILD_OIDC_TOKEN`; or fetch
+on demand from `%teamcity.serverUrl%/app/oidc-jwt/issue?aud=<audience>`.
+
+### Google service accounts (workloads on GKE / GCE)
+
+Google-signed ID tokens from `accounts.google.com`; any workload running as
+a Google service account (including GKE pods via Workload Identity) can mint
+one from the metadata server.
+
+```yaml
+- issuer:
+    url: https://accounts.google.com
+    audiences: ["kube-oidc-proxy.example.com"]
+  claimMappings:
+    username:
+      # → "gcp:deployer@my-project.iam.gserviceaccount.com"
+      expression: '"gcp:" + claims.email'
+    groups:
+      # group per GCP project, derived from the SA email domain
+      expression: '["gcp-project:" + claims.email.split("@")[1].split(".")[0]]'
+  claimValidationRules:
+  # required: with an expression-based username the authenticator does NOT
+  # auto-enforce email_verified (that only happens for `claim: email`)
+  - expression: 'claims.email_verified == true'
+    message: "unverified email claim"
+```
+
+Workload side (`format=full` is what includes the `email` claim):
+
+```bash
+TOKEN=$(curl -sH "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=kube-oidc-proxy.example.com&format=full")
+```
+
+### GKE workloads via the cluster's own issuer (per-ServiceAccount identity)
+
+Alternatively, trust a GKE cluster itself as an issuer — every Kubernetes
+ServiceAccount in it becomes a bindable identity, with no Google service
+accounts involved. GKE publishes public OIDC discovery for its
+ServiceAccount issuer. Use one entry (and one prefix) per source cluster.
+
+```yaml
+- issuer:
+    url: https://container.googleapis.com/v1/projects/MY_PROJECT/locations/MY_LOCATION/clusters/MY_CLUSTER
+    audiences: ["kube-oidc-proxy.example.com"]
+  claimMappings:
+    username:
+      # sub is "system:serviceaccount:<ns>:<sa>"; the prefix makes it
+      # collision-proof: → "gke-prod:system:serviceaccount:payments:deployer"
+      claim: sub
+      prefix: "gke-prod:"
+    groups:
+      # group per source namespace
+      expression: '["gke-prod-ns:" + claims["kubernetes.io"].namespace]'
+```
+
+Workload side — a projected token with the right audience, read from the
+mounted path and used as the bearer token:
+
+```yaml
+volumes:
+- name: cluster-access-token
+  projected:
+    sources:
+    - serviceAccountToken:
+        audience: kube-oidc-proxy.example.com
+        expirationSeconds: 600
+        path: token
+```
+
+### Internal / custom issuer with a private CA
+
+Systems you control should emit a real groups array — then no CEL is needed
+and onboarding new workloads is a change in the issuing system, not in
+cluster RBAC:
+
+```yaml
 - issuer:
     url: https://auth.internal.example.com
     audiences: ["kubernetes"]
@@ -49,7 +175,11 @@ jwt:
   claimMappings:
     username: {claim: sub, prefix: "sys-a:"}
     groups:   {claim: groups, prefix: "sys-a:"}
-# GitLab CI: username and groups built with CEL.
+```
+
+### GitLab CI
+
+```yaml
 - issuer:
     url: https://gitlab.example.com
     audiences: ["kube-oidc-proxy.example.com"]
@@ -60,20 +190,29 @@ jwt:
       expression: '["gitlab:ns:" + claims.namespace_path]'
 ```
 
-RBAC then binds the prefixed identities:
+### RBAC for the mapped identities
+
+Bindings reference the prefixed usernames and groups exactly as the
+mappings produce them:
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: gha-platform-iac-main
+  name: ci-deployers
 subjects:
+- kind: User
+  name: "tc:MyProject_Deploy"                # a single TeamCity build config
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "gke-prod-ns:payments"               # every SA in one GKE namespace
+  apiGroup: rbac.authorization.k8s.io
 - kind: User
   name: "gha:repo:my-org/platform-iac:ref:refs/heads/main"
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
-  name: edit
+  name: edit                                 # prefer purpose-built roles
   apiGroup: rbac.authorization.k8s.io
 ```
 

--- a/docs/tasks/testing-kind-github-actions.md
+++ b/docs/tasks/testing-kind-github-actions.md
@@ -1,0 +1,209 @@
+# Testing multi-issuer OIDC locally: kind + GitHub Actions tokens
+
+This guide runs kube-oidc-proxy in a local [kind](https://kind.sigs.k8s.io/)
+cluster and authenticates to it with a **real GitHub Actions OIDC token**.
+GitHub only mints these tokens inside a workflow run, so the flow is:
+
+```text
+GitHub Actions (mint token, TTL ~5 min)
+        │  gh run download
+        ▼
+local terminal ── kubectl --token=... ──► kube-oidc-proxy (kind)
+                                              │ validates JWT against
+                                              │ token.actions.githubusercontent.com
+                                              ▼ impersonates mapped identity
+                                          kind API server ── RBAC decides
+```
+
+## Prerequisites
+
+- `docker`, `kind`, `helm`, `kubectl`, `gh` (authenticated: `gh auth status`)
+- Set these once per shell — every `gh` call needs an explicit `--repo`:
+
+```bash
+export GH_SLUG="rafpe/kube-oidc-proxy"   # <owner>/<repo> hosting the mint workflow
+export BRANCH="master"
+```
+
+## 1. Token-minting workflow (one-time)
+
+Commit `.github/workflows/oidc.yaml` and push:
+
+```yaml
+name: mint-oidc-token
+on: workflow_dispatch
+permissions:
+  id-token: write
+jobs:
+  mint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v7
+      with:
+        script: |
+          const t = await core.getIDToken('kube-oidc-proxy-kind-test')
+          require('fs').writeFileSync('token.jwt', t)
+    - uses: actions/upload-artifact@v4
+      with:
+        name: oidc-token
+        path: token.jwt
+        retention-days: 1
+```
+
+> ⚠️ The artifact briefly holds a live token. It expires after ~5 minutes and
+> only grants what your **local test cluster's** RBAC allows, but treat it as
+> a secret all the same.
+
+## 2. Build the proxy image and create the cluster
+
+```bash
+docker build -t kube-oidc-proxy:test .
+kind create cluster --name oidc-test
+kind load docker-image kube-oidc-proxy:test --name oidc-test
+```
+
+## 3. Deploy the chart
+
+The `claimMappings` below use the simple `sub`-as-username mapping. The
+commented alternatives show what the CEL support enables — pick per issuer:
+
+```bash
+cat > /tmp/values-test.yaml <<'EOF'
+image:
+  repository: kube-oidc-proxy
+  tag: test
+  pullPolicy: Never
+
+authenticationConfig:
+  content: |
+    apiVersion: apiserver.config.k8s.io/v1
+    kind: AuthenticationConfiguration
+    jwt:
+    - issuer:
+        url: https://token.actions.githubusercontent.com
+        audiences: ["kube-oidc-proxy-kind-test"]
+      claimMappings:
+        # Default: bind RBAC to the raw `sub` claim. Note GitHub's newer
+        # ID-embedded format: repo:Owner@<owner_id>/repo@<repo_id>:ref:...
+        username:
+          claim: sub
+          prefix: "gha:"
+
+        # -- Alternative: readable, stable username built with CEL --
+        # Replaces the claim/prefix pair above. Produces e.g.
+        # "gha:RafPe/kube-oidc-proxy:refs/heads/master"
+        # username:
+        #   expression: '"gha:" + claims.repository + ":" + claims.ref'
+
+        # GitHub tokens carry no groups claim — CEL synthesizes one from
+        # repository_owner (case-sensitive: "RafPe" != "rafpe"):
+        groups:
+          expression: '["github:" + claims.repository_owner]'
+
+      # -- Optional hardening: pin numeric IDs so a recycled repo or owner
+      # -- name can never inherit access (find your IDs in a decoded token):
+      # claimValidationRules:
+      # - expression: 'claims.repository_owner_id == "9809655"'
+      #   message: "token not issued for the expected GitHub account"
+      # - expression: 'claims.repository_id == "1308696420"'
+      #   message: "token not issued for the expected repository"
+EOF
+
+helm install kube-oidc-proxy ./deploy/charts/kube-oidc-proxy \
+  -n kube-oidc-proxy --create-namespace -f /tmp/values-test.yaml
+kubectl -n kube-oidc-proxy rollout status deploy/kube-oidc-proxy --timeout=180s
+
+# New in this build — the proxy lists its issuers at startup:
+kubectl -n kube-oidc-proxy logs deploy/kube-oidc-proxy | grep "configured OIDC issuers"
+```
+
+Config changes later: edit the values file, `helm upgrade kube-oidc-proxy
+./deploy/charts/kube-oidc-proxy -n kube-oidc-proxy -f /tmp/values-test.yaml` —
+the checksum annotation rolls the pods automatically.
+
+## 4. RBAC
+
+Decode a token first (step 5) if you're unsure of your exact claims. With the
+default `sub` mapping and GitHub's ID-embedded subject format:
+
+```bash
+# Group binding — matches the CEL-synthesized group (mind the case!):
+kubectl create clusterrolebinding gha-owner-view \
+  --clusterrole=view --group="github:RafPe"
+
+# Exact-subject binding — GitHub's sub embeds owner/repo IDs:
+kubectl create clusterrolebinding gha-branch-view \
+  --clusterrole=view \
+  --user="gha:repo:RafPe@9809655/kube-oidc-proxy@1308696420:ref:refs/heads/master"
+
+# -- If you enabled the CEL username expression instead, bind this user: --
+# kubectl create clusterrolebinding gha-branch-view \
+#   --clusterrole=view \
+#   --user="gha:RafPe/kube-oidc-proxy:refs/heads/master"
+```
+
+## 5. Mint a token and fetch it (TTL ~5 min — move fast)
+
+```bash
+gh workflow run oidc.yaml --repo "$GH_SLUG" --ref "$BRANCH"
+sleep 5
+RUN_ID=$(gh run list --repo "$GH_SLUG" --workflow=oidc.yaml -L1 \
+  --json databaseId -q '.[0].databaseId')
+gh run watch "$RUN_ID" --repo "$GH_SLUG"
+rm -rf /tmp/oidc && gh run download "$RUN_ID" --repo "$GH_SLUG" \
+  -n oidc-token -D /tmp/oidc
+TOKEN=$(cat /tmp/oidc/token.jwt)
+
+# Inspect the claims you are about to authenticate with:
+echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null \
+  | jq '{iss,aud,sub,repository,repository_owner,ref}'
+```
+
+## 6. Test through the proxy
+
+```bash
+kubectl -n kube-oidc-proxy port-forward svc/kube-oidc-proxy 8443:443 &
+sleep 3
+```
+
+The one-liner identity check — who does the cluster think you are?
+
+```bash
+kubectl --server=https://127.0.0.1:8443 --insecure-skip-tls-verify=true \
+  --token="$TOKEN" auth whoami
+```
+
+Expected: your prefixed username plus groups `[github:RafPe, system:authenticated]`.
+Then prove authorization scoping:
+
+```bash
+PROXY="--server=https://127.0.0.1:8443 --insecure-skip-tls-verify=true --token=$TOKEN"
+kubectl $PROXY get pods -A        # allowed  (view)
+kubectl $PROXY create ns nope     # forbidden (view cannot write)
+```
+
+If you get `401`: the token expired — rerun step 5. Steps 2–4 stay up.
+
+> `--insecure-skip-tls-verify` is acceptable only against this throwaway kind
+> cluster (the chart generated an ephemeral self-signed cert). Real
+> deployments set `tls.secretName`/cert-manager and ship the CA in kubeconfig.
+
+## 7. Access logs and cleanup
+
+```bash
+kubectl -n kube-oidc-proxy logs deploy/kube-oidc-proxy --tail=20   # AuSuccess / AuFail
+kill %1
+kind delete cluster --name oidc-test
+```
+
+## Adding the next system
+
+A pure config change — no new deployments:
+
+1. Append another `jwt:` entry to `authenticationConfig.content` (its issuer
+   URL, its own audience, and a **distinct prefix**, e.g. `sys-a:` — never
+   reuse or omit prefixes across issuers).
+2. Add RBAC bindings for the new prefixed identities.
+3. `helm upgrade` — pods roll automatically; with the default readiness mode
+   the rollout completes even if the new issuer is temporarily unreachable
+   (it is logged as pending and starts working the moment its JWKS loads).

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/heptiolabs/healthcheck"
@@ -19,19 +20,17 @@ const (
 )
 
 type HealthCheck struct {
-	handler healthcheck.Handler
-
+	handler    healthcheck.Handler
 	oidcAuther authenticator.Token
-	fakeJWT    string
-
-	ready bool
+	fakeJWTs   []string
+	ready      atomic.Bool
 }
 
-func Run(port, fakeJWT string, oidcAuther authenticator.Token) error {
+func Run(port string, fakeJWTs []string, oidcAuther authenticator.Token) error {
 	h := &HealthCheck{
 		handler:    healthcheck.NewHandler(),
 		oidcAuther: oidcAuther,
-		fakeJWT:    fakeJWT,
+		fakeJWTs:   fakeJWTs,
 	}
 
 	h.handler.AddReadinessCheck("secure serving", h.Check)
@@ -50,23 +49,23 @@ func Run(port, fakeJWT string, oidcAuther authenticator.Token) error {
 }
 
 func (h *HealthCheck) Check() error {
-	if h.ready {
+	if h.ready.Load() {
 		return nil
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	_, _, err := h.oidcAuther.AuthenticateToken(ctx, h.fakeJWT)
-	if err != nil && strings.HasSuffix(err.Error(), "authenticator not initialized") {
-		err = fmt.Errorf("OIDC provider not yet initialized: %s", err)
-		klog.V(4).Infof("%v", err.Error())
-		return err
+	for _, fakeJWT := range h.fakeJWTs {
+		_, _, err := h.oidcAuther.AuthenticateToken(ctx, fakeJWT)
+		if err != nil && strings.HasSuffix(err.Error(), "authenticator not initialized") {
+			err = fmt.Errorf("OIDC provider not yet initialized: %w", err)
+			klog.V(4).Info(err)
+			return err
+		}
 	}
 
-	h.ready = true
-
+	h.ready.Store(true)
 	klog.V(4).Info("OIDC provider initialized.")
-
 	return nil
 }

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -32,14 +33,18 @@ type HealthCheck struct {
 	issuers    []IssuerReadiness
 	requireAll bool
 	ready      atomic.Bool
+
+	mu          sync.Mutex
+	initialized map[string]bool
 }
 
 func Run(port string, issuers []IssuerReadiness, requireAll bool, oidcAuther authenticator.Token) error {
 	h := &HealthCheck{
-		handler:    healthcheck.NewHandler(),
-		oidcAuther: oidcAuther,
-		issuers:    issuers,
-		requireAll: requireAll,
+		handler:     healthcheck.NewHandler(),
+		oidcAuther:  oidcAuther,
+		issuers:     issuers,
+		requireAll:  requireAll,
+		initialized: make(map[string]bool),
 	}
 
 	h.handler.AddReadinessCheck("secure serving", h.Check)
@@ -57,32 +62,47 @@ func Run(port string, issuers []IssuerReadiness, requireAll bool, oidcAuther aut
 	return nil
 }
 
+// Check probes every issuer that has not yet been observed as initialized,
+// logs per-issuer transitions and any still-pending issuers, and reports
+// readiness. Once readiness latches (via ready.Store(true)) it always
+// returns nil, but probing and pending-issuer logging continue on every
+// call so operators keep seeing progress for issuers that initialize late.
 func (h *HealthCheck) Check() error {
-	if h.ready.Load() {
-		return nil
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	var pending []string
 	for _, issuer := range h.issuers {
+		if h.initialized[issuer.IssuerURL] {
+			continue
+		}
+
 		_, _, err := h.oidcAuther.AuthenticateToken(ctx, issuer.FakeJWT)
 		if err != nil && strings.HasSuffix(err.Error(), "authenticator not initialized") {
 			pending = append(pending, issuer.IssuerURL)
+			continue
 		}
+
+		h.initialized[issuer.IssuerURL] = true
+		klog.Infof("OIDC issuer initialized: %s (%d/%d ready)", issuer.IssuerURL, len(h.initialized), len(h.issuers))
 	}
 
-	initialized := len(h.issuers) - len(pending)
 	if len(pending) > 0 {
 		klog.Infof("readiness: %d/%d OIDC issuers initialized, pending: %v",
-			initialized, len(h.issuers), pending)
+			len(h.initialized), len(h.issuers), pending)
+	}
+
+	if h.ready.Load() {
+		return nil
 	}
 
 	if h.requireAll && len(pending) > 0 {
 		return fmt.Errorf("OIDC providers not yet initialized: %v", pending)
 	}
-	if !h.requireAll && initialized == 0 {
+	if !h.requireAll && len(h.initialized) == 0 {
 		return fmt.Errorf("no OIDC provider initialized yet: %v", pending)
 	}
 

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -19,18 +19,27 @@ const (
 	timeout = time.Second * 10
 )
 
+// IssuerReadiness pairs an issuer with the fake JWT used to probe whether
+// its authenticator has completed JWKS initialization.
+type IssuerReadiness struct {
+	IssuerURL string
+	FakeJWT   string
+}
+
 type HealthCheck struct {
 	handler    healthcheck.Handler
 	oidcAuther authenticator.Token
-	fakeJWTs   []string
+	issuers    []IssuerReadiness
+	requireAll bool
 	ready      atomic.Bool
 }
 
-func Run(port string, fakeJWTs []string, oidcAuther authenticator.Token) error {
+func Run(port string, issuers []IssuerReadiness, requireAll bool, oidcAuther authenticator.Token) error {
 	h := &HealthCheck{
 		handler:    healthcheck.NewHandler(),
 		oidcAuther: oidcAuther,
-		fakeJWTs:   fakeJWTs,
+		issuers:    issuers,
+		requireAll: requireAll,
 	}
 
 	h.handler.AddReadinessCheck("secure serving", h.Check)
@@ -56,16 +65,28 @@ func (h *HealthCheck) Check() error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	for _, fakeJWT := range h.fakeJWTs {
-		_, _, err := h.oidcAuther.AuthenticateToken(ctx, fakeJWT)
+	var pending []string
+	for _, issuer := range h.issuers {
+		_, _, err := h.oidcAuther.AuthenticateToken(ctx, issuer.FakeJWT)
 		if err != nil && strings.HasSuffix(err.Error(), "authenticator not initialized") {
-			err = fmt.Errorf("OIDC provider not yet initialized: %w", err)
-			klog.V(4).Info(err)
-			return err
+			pending = append(pending, issuer.IssuerURL)
 		}
 	}
 
+	initialized := len(h.issuers) - len(pending)
+	if len(pending) > 0 {
+		klog.Infof("readiness: %d/%d OIDC issuers initialized, pending: %v",
+			initialized, len(h.issuers), pending)
+	}
+
+	if h.requireAll && len(pending) > 0 {
+		return fmt.Errorf("OIDC providers not yet initialized: %v", pending)
+	}
+	if !h.requireAll && initialized == 0 {
+		return fmt.Errorf("no OIDC provider initialized yet: %v", pending)
+	}
+
 	h.ready.Store(true)
-	klog.V(4).Info("OIDC provider initialized.")
+	klog.V(4).Info("OIDC provider(s) initialized, marking ready.")
 	return nil
 }

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -100,10 +100,10 @@ func (h *HealthCheck) Check() error {
 	}
 
 	if h.requireAll && len(pending) > 0 {
-		return fmt.Errorf("OIDC providers not yet initialized: %v", pending)
+		return errors.New("OIDC providers not yet initialized")
 	}
 	if !h.requireAll && len(h.initialized) == 0 {
-		return fmt.Errorf("no OIDC provider initialized yet: %v", pending)
+		return errors.New("no OIDC provider initialized yet")
 	}
 
 	h.ready.Store(true)

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -4,87 +4,98 @@ package probe
 import (
 	"context"
 	"errors"
-	"fmt"
-	"net/http"
 	"testing"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 
-	"github.com/jetstack/kube-oidc-proxy/pkg/util"
+	"github.com/heptiolabs/healthcheck"
 )
 
-type fakeTokenAuthenticator struct {
-	notInitialized bool
+// fakeAuther simulates the union authenticator: tokens listed in notInit
+// hit an issuer whose JWKS is not yet fetched; every other token reaches
+// an initialized issuer and fails ordinary verification.
+type fakeAuther struct {
+	notInit map[string]bool
 }
 
-var _ authenticator.Token = &fakeTokenAuthenticator{}
-
-func (f *fakeTokenAuthenticator) AuthenticateToken(_ context.Context, _ string) (*authenticator.Response, bool, error) {
-	if f.notInitialized {
-		return nil, false, errors.New("foo bar authenticator not initialized")
+func (f *fakeAuther) AuthenticateToken(_ context.Context, token string) (*authenticator.Response, bool, error) {
+	if f.notInit[token] {
+		return nil, false, errors.New("oidc: authenticator not initialized")
 	}
-	return nil, false, errors.New("some other error")
+	return nil, false, errors.New("oidc: verify token: signature invalid")
 }
 
-func TestRun(t *testing.T) {
-	t.Skip("skipping probe test")
+func newTestHealthCheck(requireAll bool, notInit map[string]bool, issuers ...IssuerReadiness) *HealthCheck {
+	return &HealthCheck{
+		handler:    healthcheck.NewHandler(),
+		oidcAuther: &fakeAuther{notInit: notInit},
+		issuers:    issuers,
+		requireAll: requireAll,
+	}
+}
 
-	f := &fakeTokenAuthenticator{notInitialized: true}
+func TestCheckReadiness(t *testing.T) {
+	issuerA := IssuerReadiness{IssuerURL: "https://a.example.com", FakeJWT: "jwt-a"}
+	issuerB := IssuerReadiness{IssuerURL: "https://b.example.com", FakeJWT: "jwt-b"}
 
-	port, err := util.FreePort()
-	if err != nil {
-		t.Fatalf("FreePort() unexpected error: %v", err)
+	tests := []struct {
+		name       string
+		requireAll bool
+		notInit    map[string]bool
+		wantReady  bool
+	}{
+		{
+			name:       "default mode: one of two initialized is ready",
+			requireAll: false,
+			notInit:    map[string]bool{"jwt-b": true},
+			wantReady:  true,
+		},
+		{
+			name:       "default mode: none initialized is not ready",
+			requireAll: false,
+			notInit:    map[string]bool{"jwt-a": true, "jwt-b": true},
+			wantReady:  false,
+		},
+		{
+			name:       "require-all: one pending is not ready",
+			requireAll: true,
+			notInit:    map[string]bool{"jwt-b": true},
+			wantReady:  false,
+		},
+		{
+			name:       "require-all: all initialized is ready",
+			requireAll: true,
+			notInit:    map[string]bool{},
+			wantReady:  true,
+		},
 	}
 
-	fakeJWT1, err := util.FakeJWT("https://issuer1.example.com")
-	if err != nil {
-		t.Fatalf("FakeJWT() unexpected error: %v", err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHealthCheck(tc.requireAll, tc.notInit, issuerA, issuerB)
+			err := h.Check()
+			if tc.wantReady && err != nil {
+				t.Fatalf("expected ready, got error: %v", err)
+			}
+			if !tc.wantReady && err == nil {
+				t.Fatal("expected not ready, got nil error")
+			}
+		})
 	}
-	fakeJWT2, err := util.FakeJWT("https://issuer2.example.com")
-	if err != nil {
-		t.Fatalf("FakeJWT() unexpected error: %v", err)
+}
+
+func TestCheckReadinessIsSticky(t *testing.T) {
+	issuerA := IssuerReadiness{IssuerURL: "https://a.example.com", FakeJWT: "jwt-a"}
+	notInit := map[string]bool{}
+	h := newTestHealthCheck(false, notInit, issuerA)
+
+	if err := h.Check(); err != nil {
+		t.Fatalf("expected ready, got: %v", err)
 	}
 
-	if err := Run(port, []string{fakeJWT1, fakeJWT2}, f); err != nil {
-		t.Fatalf("Run() unexpected error: %v", err)
-	}
-
-	url := fmt.Sprintf("http://0.0.0.0:%s", port)
-
-	var resp *http.Response
-	for i := 0; i < 5; i++ {
-		resp, err = http.Get(url + "/ready")
-		if err == nil {
-			break
-		}
-	}
-	if err != nil {
-		t.Fatalf("unexpected error reaching probe: %s", err)
-	}
-
-	if resp.StatusCode != 503 {
-		t.Errorf("expected probe not ready, got %d", resp.StatusCode)
-	}
-
-	// Mark initialized — all JWTs now pass.
-	f.notInitialized = false
-
-	resp, err = http.Get(url + "/ready")
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-	if resp.StatusCode != 200 {
-		t.Errorf("expected probe ready, got %d", resp.StatusCode)
-	}
-
-	// Once latched ready, stays ready even if authenticator errors again.
-	f.notInitialized = true
-
-	resp, err = http.Get(url + "/ready")
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-	if resp.StatusCode != 200 {
-		t.Errorf("expected probe to remain ready after latch, got %d", resp.StatusCode)
+	// Simulate the issuer regressing to uninitialized: readiness must stick.
+	notInit["jwt-a"] = true
+	if err := h.Check(); err != nil {
+		t.Fatalf("expected readiness to be sticky, got: %v", err)
 	}
 }

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -4,6 +4,7 @@ package probe
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
@@ -15,22 +16,38 @@ import (
 // hit an issuer whose JWKS is not yet fetched; every other token reaches
 // an initialized issuer and fails ordinary verification.
 type fakeAuther struct {
+	mu      sync.Mutex
 	notInit map[string]bool
+	calls   map[string]int
 }
 
 func (f *fakeAuther) AuthenticateToken(_ context.Context, token string) (*authenticator.Response, bool, error) {
+	f.mu.Lock()
+	if f.calls == nil {
+		f.calls = make(map[string]int)
+	}
+	f.calls[token]++
+	f.mu.Unlock()
+
 	if f.notInit[token] {
 		return nil, false, errors.New("oidc: authenticator not initialized")
 	}
 	return nil, false, errors.New("oidc: verify token: signature invalid")
 }
 
+func (f *fakeAuther) callCount(token string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[token]
+}
+
 func newTestHealthCheck(requireAll bool, notInit map[string]bool, issuers ...IssuerReadiness) *HealthCheck {
 	return &HealthCheck{
-		handler:    healthcheck.NewHandler(),
-		oidcAuther: &fakeAuther{notInit: notInit},
-		issuers:    issuers,
-		requireAll: requireAll,
+		handler:     healthcheck.NewHandler(),
+		oidcAuther:  &fakeAuther{notInit: notInit},
+		issuers:     issuers,
+		requireAll:  requireAll,
+		initialized: make(map[string]bool),
 	}
 }
 
@@ -97,5 +114,62 @@ func TestCheckReadinessIsSticky(t *testing.T) {
 	notInit["jwt-a"] = true
 	if err := h.Check(); err != nil {
 		t.Fatalf("expected readiness to be sticky, got: %v", err)
+	}
+}
+
+// TestCheckContinuesProbingPendingAfterLatch verifies that once readiness
+// latches (default mode, one of two issuers initialized), subsequent Check
+// calls still return nil AND still probe the still-pending issuer so it can
+// transition to initialized and be logged, while the already-initialized
+// issuer is not re-probed.
+func TestCheckContinuesProbingPendingAfterLatch(t *testing.T) {
+	issuerA := IssuerReadiness{IssuerURL: "https://a.example.com", FakeJWT: "jwt-a"}
+	issuerB := IssuerReadiness{IssuerURL: "https://b.example.com", FakeJWT: "jwt-b"}
+
+	notInit := map[string]bool{"jwt-b": true}
+	h := newTestHealthCheck(false, notInit, issuerA, issuerB)
+	fake := h.oidcAuther.(*fakeAuther)
+
+	if err := h.Check(); err != nil {
+		t.Fatalf("expected ready (issuer A initialized), got: %v", err)
+	}
+	if !h.ready.Load() {
+		t.Fatal("expected readiness to have latched")
+	}
+
+	aCallsAfterFirst := fake.callCount("jwt-a")
+	bCallsAfterFirst := fake.callCount("jwt-b")
+	if aCallsAfterFirst != 1 || bCallsAfterFirst != 1 {
+		t.Fatalf("expected 1 call each after first Check, got a=%d b=%d", aCallsAfterFirst, bCallsAfterFirst)
+	}
+
+	// Second Check: readiness already latched, so it must return nil
+	// regardless of issuer B still being pending, but issuer B must still
+	// be probed (call count increases) while issuer A (already
+	// initialized) must not be re-probed.
+	if err := h.Check(); err != nil {
+		t.Fatalf("expected nil error once latched even with issuer B pending, got: %v", err)
+	}
+
+	if got := fake.callCount("jwt-a"); got != aCallsAfterFirst {
+		t.Fatalf("expected initialized issuer A not to be re-probed, call count changed from %d to %d", aCallsAfterFirst, got)
+	}
+	if got := fake.callCount("jwt-b"); got <= bCallsAfterFirst {
+		t.Fatalf("expected pending issuer B to still be probed, call count did not increase (still %d)", got)
+	}
+
+	// Now let issuer B initialize and confirm the transition is picked up
+	// and it is subsequently no longer re-probed either.
+	delete(notInit, "jwt-b")
+	if err := h.Check(); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	bCallsAfterInit := fake.callCount("jwt-b")
+
+	if err := h.Check(); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if got := fake.callCount("jwt-b"); got != bCallsAfterInit {
+		t.Fatalf("expected issuer B not to be re-probed once initialized, call count changed from %d to %d", bCallsAfterInit, got)
 	}
 }

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -14,88 +14,77 @@ import (
 )
 
 type fakeTokenAuthenticator struct {
-	returnErr bool
+	notInitialized bool
 }
 
 var _ authenticator.Token = &fakeTokenAuthenticator{}
 
-func (f *fakeTokenAuthenticator) AuthenticateToken(context.Context, string) (*authenticator.Response, bool, error) {
-	if f.returnErr {
+func (f *fakeTokenAuthenticator) AuthenticateToken(_ context.Context, _ string) (*authenticator.Response, bool, error) {
+	if f.notInitialized {
 		return nil, false, errors.New("foo bar authenticator not initialized")
 	}
-
 	return nil, false, errors.New("some other error")
 }
 
 func TestRun(t *testing.T) {
-	f := &fakeTokenAuthenticator{
-		returnErr: true,
-	}
+	t.Skip("skipping probe test")
+
+	f := &fakeTokenAuthenticator{notInitialized: true}
 
 	port, err := util.FreePort()
 	if err != nil {
-		t.Error(err.Error())
-		t.FailNow()
+		t.Fatalf("FreePort() unexpected error: %v", err)
 	}
 
-	fakeJWT, err := util.FakeJWT("issuer")
+	fakeJWT1, err := util.FakeJWT("https://issuer1.example.com")
 	if err != nil {
-		t.Error(err.Error())
-		t.FailNow()
+		t.Fatalf("FakeJWT() unexpected error: %v", err)
+	}
+	fakeJWT2, err := util.FakeJWT("https://issuer2.example.com")
+	if err != nil {
+		t.Fatalf("FakeJWT() unexpected error: %v", err)
 	}
 
-	if err := Run(port, fakeJWT, f); err != nil {
-		t.Error(err.Error())
-		t.FailNow()
+	if err := Run(port, []string{fakeJWT1, fakeJWT2}, f); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
 	}
 
 	url := fmt.Sprintf("http://0.0.0.0:%s", port)
 
 	var resp *http.Response
-	var i int
-
-	for {
+	for i := 0; i < 5; i++ {
 		resp, err = http.Get(url + "/ready")
 		if err == nil {
 			break
 		}
-
-		if i >= 5 {
-			t.Errorf("unexpected error: %s", err)
-			t.FailNow()
-		}
-		i++
+	}
+	if err != nil {
+		t.Fatalf("unexpected error reaching probe: %s", err)
 	}
 
 	if resp.StatusCode != 503 {
-		t.Errorf("expected ready probe to be responding and not ready, exp=%d got=%d",
-			503, resp.StatusCode)
+		t.Errorf("expected probe not ready, got %d", resp.StatusCode)
 	}
 
-	f.returnErr = false
+	// Mark initialized — all JWTs now pass.
+	f.notInitialized = false
 
 	resp, err = http.Get(url + "/ready")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-
 	if resp.StatusCode != 200 {
-		t.Errorf("expected ready probe to be responding and ready, exp=%d got=%d",
-			200, resp.StatusCode)
+		t.Errorf("expected probe ready, got %d", resp.StatusCode)
 	}
 
-	// Once the authenticator has returned with an non-initialised error, then
-	// should always return ready
-
-	f.returnErr = true
+	// Once latched ready, stays ready even if authenticator errors again.
+	f.notInitialized = true
 
 	resp, err = http.Get(url + "/ready")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-
 	if resp.StatusCode != 200 {
-		t.Errorf("expected ready probe to be responding and ready, exp=%d got=%d",
-			200, resp.StatusCode)
+		t.Errorf("expected probe to remain ready after latch, got %d", resp.StatusCode)
 	}
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -2,20 +2,16 @@
 package proxy
 
 import (
-	ctx "context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"time"
 
-	"k8s.io/apiserver/pkg/apis/apiserver"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
 	"k8s.io/apiserver/pkg/server"
-	"k8s.io/apiserver/plugin/pkg/authenticator/token/oidc"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 	"k8s.io/klog/v2"
@@ -71,60 +67,13 @@ type Proxy struct {
 	handleError errorHandlerFn
 }
 
-// implement oidc.CAContentProvider to load
-// the ca file from the options
-type CAFromFile struct {
-	CAFile string
-}
-
-func (caFromFile CAFromFile) CurrentCABundleContent() []byte {
-	res, _ := ioutil.ReadFile(caFromFile.CAFile)
-	return res
-}
-
 func New(restConfig *rest.Config,
-	oidcOptions *options.OIDCAuthenticationOptions,
+	tokenAuther authenticator.Token,
 	auditOptions *options.AuditOptions,
 	tokenReviewer *tokenreview.TokenReview,
 	subjectAccessReviewer *subjectaccessreview.SubjectAccessReview,
 	ssinfo *server.SecureServingInfo,
 	config *Config) (*Proxy, error) {
-
-	// load the CA from the file listed in the options
-	caFromFile := CAFromFile{
-		CAFile: oidcOptions.CAFile,
-	}
-
-	// setup static JWT Auhenticator
-	jwtConfig := apiserver.JWTAuthenticator{
-		Issuer: apiserver.Issuer{
-			URL:                  oidcOptions.IssuerURL,
-			Audiences:            []string{oidcOptions.ClientID},
-			CertificateAuthority: string(caFromFile.CurrentCABundleContent()),
-		},
-
-		ClaimMappings: apiserver.ClaimMappings{
-			Username: apiserver.PrefixedClaimOrExpression{
-				Claim:  oidcOptions.UsernameClaim,
-				Prefix: &oidcOptions.UsernamePrefix,
-			},
-			Groups: apiserver.PrefixedClaimOrExpression{
-				Claim:  oidcOptions.GroupsClaim,
-				Prefix: &oidcOptions.GroupsPrefix,
-			},
-		},
-	}
-
-	// generate tokenAuther from oidc config
-	tokenAuther, err := oidc.New(ctx.TODO(), oidc.Options{
-		CAContentProvider: caFromFile,
-		//RequiredClaims:       oidcOptions.RequiredClaims,
-		SupportedSigningAlgs: oidcOptions.SigningAlgs,
-		JWTAuthenticator:     jwtConfig,
-	})
-	if err != nil {
-		return nil, err
-	}
 
 	auditor, err := audit.New(auditOptions, config.ExternalAddress, ssinfo)
 	if err != nil {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -30,6 +30,15 @@ type Framework struct {
 
 	Namespace *corev1.Namespace
 
+	// BeforeProxyDeploy, if set, runs after the primary issuer is deployed and
+	// before the proxy is deployed. Tests use it to stage resources the proxy
+	// needs at startup (e.g. an AuthenticationConfiguration ConfigMap) and to
+	// populate ExtraProxyVolumes / ExtraProxyArgs. Avoids a delete-redeploy
+	// cycle for tests that need non-default proxy flags.
+	BeforeProxyDeploy func()
+	ExtraProxyVolumes []corev1.Volume
+	ExtraProxyArgs    []string
+
 	config *config.Config
 	helper *helper.Helper
 
@@ -78,13 +87,18 @@ func (f *Framework) BeforeEach() {
 	issuerKeyBundle, issuerURL, err := f.helper.DeployIssuer(f.Namespace.Name)
 	Expect(err).NotTo(HaveOccurred())
 
+	f.issuerURL, f.issuerKeyBundle = issuerURL, issuerKeyBundle
+
+	if f.BeforeProxyDeploy != nil {
+		f.BeforeProxyDeploy()
+	}
+
 	By("Deploying kube-oidc-proxy")
 	proxyKeyBundle, proxyURL, err := f.helper.DeployProxy(f.Namespace,
-		issuerURL, clientID, issuerKeyBundle, nil)
+		issuerURL, clientID, issuerKeyBundle, f.ExtraProxyVolumes, f.ExtraProxyArgs...)
 	Expect(err).NotTo(HaveOccurred())
 
-	f.issuerURL, f.proxyURL = issuerURL, proxyURL
-	f.issuerKeyBundle, f.proxyKeyBundle = issuerKeyBundle, proxyKeyBundle
+	f.proxyURL, f.proxyKeyBundle = proxyURL, proxyKeyBundle
 
 	By("Creating Proxy Client")
 	f.ProxyClient = f.NewProxyClient()

--- a/test/e2e/framework/helper/deploy.go
+++ b/test/e2e/framework/helper/deploy.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,35 +23,54 @@ import (
 
 func (h *Helper) DeployProxy(ns *corev1.Namespace, issuerURL *url.URL, clientID string,
 	oidcKeyBundle *util.KeyBundle, extraVolumes []corev1.Volume, extraArgs ...string) (*util.KeyBundle, *url.URL, error) {
-	cnt := corev1.Container{
-		Name:            kind.ProxyImageName,
-		Image:           kind.ProxyImageName,
-		ImagePullPolicy: corev1.PullNever,
-		Args: append([]string{
-			"kube-oidc-proxy",
-			"--secure-port=6443",
-			"--tls-cert-file=/tls/cert.pem",
-			"--tls-private-key-file=/tls/key.pem",
+	authConfig := false
+	for _, a := range extraArgs {
+		if strings.HasPrefix(a, "--authentication-config") {
+			authConfig = true
+			break
+		}
+	}
+
+	args := []string{
+		"kube-oidc-proxy",
+		"--secure-port=6443",
+		"--tls-cert-file=/tls/cert.pem",
+		"--tls-private-key-file=/tls/key.pem",
+	}
+	if !authConfig {
+		args = append(args,
 			fmt.Sprintf("--oidc-client-id=%s", clientID),
 			fmt.Sprintf("--oidc-issuer-url=%s", issuerURL),
 			"--oidc-username-claim=email",
 			"--oidc-groups-claim=groups",
 			"--oidc-ca-file=/oidc/ca.pem",
 			"--oidc-ca-file=/oidc/ca.pem",
-			"--v=10",
-		}, extraArgs...),
-		VolumeMounts: []corev1.VolumeMount{
-			corev1.VolumeMount{
-				MountPath: "/tls",
-				Name:      "tls",
-				ReadOnly:  true,
-			},
-			corev1.VolumeMount{
-				MountPath: "/oidc",
-				Name:      "oidc",
-				ReadOnly:  true,
-			},
+		)
+	}
+	args = append(args, "--v=10")
+	args = append(args, extraArgs...)
+
+	volumeMounts := []corev1.VolumeMount{
+		corev1.VolumeMount{
+			MountPath: "/tls",
+			Name:      "tls",
+			ReadOnly:  true,
 		},
+	}
+	if !authConfig {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			MountPath: "/oidc",
+			Name:      "oidc",
+			ReadOnly:  true,
+		})
+	}
+
+	cnt := corev1.Container{
+		Name:            kind.ProxyImageName,
+		Image:           kind.ProxyImageName,
+		ImagePullPolicy: corev1.PullNever,
+		Args:            args,
+		VolumeMounts:    volumeMounts,
 		Ports: []corev1.ContainerPort{
 			corev1.ContainerPort{
 				ContainerPort: 6443,
@@ -79,28 +99,30 @@ func (h *Helper) DeployProxy(ns *corev1.Namespace, issuerURL *url.URL, clientID 
 		})
 	}
 
-	volumes := append(extraVolumes, corev1.Volume{
-		Name: "oidc",
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName: "oidc-ca",
+	volumes := extraVolumes
+	if !authConfig {
+		volumes = append(volumes, corev1.Volume{
+			Name: "oidc",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "oidc-ca",
+				},
 			},
-		},
-	})
+		})
 
-	sec := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "oidc-ca",
-			Namespace: ns.Name,
-		},
-		Data: map[string][]byte{
-			"ca.pem": oidcKeyBundle.CertBytes,
-		},
-	}
+		sec := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oidc-ca",
+				Namespace: ns.Name,
+			},
+			Data: map[string][]byte{
+				"ca.pem": oidcKeyBundle.CertBytes,
+			},
+		}
 
-	_, err := h.KubeClient.CoreV1().Secrets(ns.Name).Create(context.TODO(), sec, metav1.CreateOptions{})
-	if err != nil {
-		return nil, nil, err
+		if _, err := h.KubeClient.CoreV1().Secrets(ns.Name).Create(context.TODO(), sec, metav1.CreateOptions{}); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	bundle, appURL, err := h.deployApp(ns.Name, kind.ProxyImageName, corev1.ServiceTypeNodePort, cnt, volumes...)
@@ -245,6 +267,10 @@ func (h *Helper) DeployProxy(ns *corev1.Namespace, issuerURL *url.URL, clientID 
 }
 
 func (h *Helper) DeployIssuer(ns string) (*util.KeyBundle, *url.URL, error) {
+	return h.DeployNamedIssuer(ns, kind.IssuerImageName)
+}
+
+func (h *Helper) DeployNamedIssuer(ns, name string) (*util.KeyBundle, *url.URL, error) {
 	cnt := corev1.Container{
 		Name:            kind.IssuerImageName,
 		Image:           kind.IssuerImageName,
@@ -252,7 +278,7 @@ func (h *Helper) DeployIssuer(ns string) (*util.KeyBundle, *url.URL, error) {
 		Args: []string{
 			"oidc-issuer",
 			"--secure-port=6443",
-			fmt.Sprintf("--issuer-url=https://oidc-issuer-e2e.%s.svc.cluster.local:6443", ns),
+			fmt.Sprintf("--issuer-url=https://%s.%s.svc.cluster.local:6443", name, ns),
 			"--tls-cert-file=/tls/cert.pem",
 			"--tls-private-key-file=/tls/key.pem",
 		},
@@ -270,7 +296,7 @@ func (h *Helper) DeployIssuer(ns string) (*util.KeyBundle, *url.URL, error) {
 		},
 	}
 
-	bundle, appURL, err := h.deployApp(ns, kind.IssuerImageName, corev1.ServiceTypeClusterIP, cnt)
+	bundle, appURL, err := h.deployApp(ns, name, corev1.ServiceTypeClusterIP, cnt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -537,7 +563,10 @@ func (h *Helper) DeleteProxy(ns string) error {
 	return h.deleteApp(ns, kind.ProxyImageName, "oidc-ca")
 }
 func (h *Helper) DeleteIssuer(ns string) error {
-	return h.deleteApp(ns, kind.IssuerImageName)
+	return h.DeleteNamedIssuer(ns, kind.IssuerImageName)
+}
+func (h *Helper) DeleteNamedIssuer(ns, name string) error {
+	return h.deleteApp(ns, name)
 }
 func (h *Helper) DeleteFakeAPIServer(ns string) error {
 	return h.deleteApp(ns, kind.FakeAPIServerImageName)

--- a/test/e2e/suite/cases/authconfig/authconfig.go
+++ b/test/e2e/suite/cases/authconfig/authconfig.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
+	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
@@ -68,27 +68,27 @@ var _ = framework.CasesDescribe("AuthenticationConfiguration multi-issuer", func
 	})
 })
 
-func authConfig(jwts ...apiserverv1beta1.JWTAuthenticator) apiserverv1beta1.AuthenticationConfiguration {
-	return apiserverv1beta1.AuthenticationConfiguration{
+func authConfig(jwts ...apiserverv1.JWTAuthenticator) apiserverv1.AuthenticationConfiguration {
+	return apiserverv1.AuthenticationConfiguration{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apiserver.config.k8s.io/v1beta1",
+			APIVersion: "apiserver.config.k8s.io/v1",
 			Kind:       "AuthenticationConfiguration",
 		},
 		JWT: jwts,
 	}
 }
 
-func jwtAuthenticator(issuerURL, audience string, caBundle []byte) apiserverv1beta1.JWTAuthenticator {
+func jwtAuthenticator(issuerURL, audience string, caBundle []byte) apiserverv1.JWTAuthenticator {
 	emptyPrefix := ""
-	return apiserverv1beta1.JWTAuthenticator{
-		Issuer: apiserverv1beta1.Issuer{
+	return apiserverv1.JWTAuthenticator{
+		Issuer: apiserverv1.Issuer{
 			URL:                  issuerURL,
 			Audiences:            []string{audience},
 			CertificateAuthority: string(caBundle),
 		},
-		ClaimMappings: apiserverv1beta1.ClaimMappings{
-			Username: apiserverv1beta1.PrefixedClaimOrExpression{Claim: "email", Prefix: &emptyPrefix},
-			Groups:   apiserverv1beta1.PrefixedClaimOrExpression{Claim: "groups", Prefix: &emptyPrefix},
+		ClaimMappings: apiserverv1.ClaimMappings{
+			Username: apiserverv1.PrefixedClaimOrExpression{Claim: "email", Prefix: &emptyPrefix},
+			Groups:   apiserverv1.PrefixedClaimOrExpression{Claim: "groups", Prefix: &emptyPrefix},
 		},
 	}
 }

--- a/test/e2e/suite/cases/authconfig/authconfig.go
+++ b/test/e2e/suite/cases/authconfig/authconfig.go
@@ -1,0 +1,105 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package authconfig
+
+import (
+	"context"
+	"net/url"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
+	"github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/sharedtests"
+	"github.com/jetstack/kube-oidc-proxy/test/util"
+)
+
+const (
+	issuer2Name      = "oidc-issuer2-e2e"
+	authConfigVolume = "auth-config"
+	authConfigKey    = "config.yaml"
+)
+
+var _ = framework.CasesDescribe("AuthenticationConfiguration multi-issuer", func() {
+	f := framework.NewDefaultFramework("authconfig")
+
+	var (
+		issuer2Bundle *util.KeyBundle
+		issuer2URL    *url.URL
+	)
+
+	f.BeforeProxyDeploy = func() {
+		var err error
+
+		By("Deploying second OIDC issuer")
+		issuer2Bundle, issuer2URL, err = f.Helper().DeployNamedIssuer(f.Namespace.Name, issuer2Name)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating AuthenticationConfiguration ConfigMap")
+		cfgYAML, err := yaml.Marshal(authConfig(
+			jwtAuthenticator(f.IssuerURL().String(), f.ClientID(), f.IssuerKeyBundle().CertBytes),
+			jwtAuthenticator(issuer2URL.String(), f.ClientID(), issuer2Bundle.CertBytes),
+		))
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = f.KubeClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(
+			context.TODO(),
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: authConfigVolume},
+				Data:       map[string]string{authConfigKey: string(cfgYAML)},
+			},
+			metav1.CreateOptions{},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		f.ExtraProxyVolumes = []corev1.Volume{configMapVolume(authConfigVolume)}
+		f.ExtraProxyArgs = []string{"--authentication-config=/" + authConfigVolume + "/" + authConfigKey}
+	}
+
+	sharedtests.RunTokenValidationTests(f)
+
+	It("accepts a valid token from the second configured issuer", func() {
+		payload := f.Helper().NewTokenPayload(issuer2URL, f.ClientID(), time.Now().Add(time.Minute))
+		sharedtests.ExpectProxyAuthenticated(f, issuer2Bundle, payload)
+	})
+})
+
+func authConfig(jwts ...apiserverv1beta1.JWTAuthenticator) apiserverv1beta1.AuthenticationConfiguration {
+	return apiserverv1beta1.AuthenticationConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiserver.config.k8s.io/v1beta1",
+			Kind:       "AuthenticationConfiguration",
+		},
+		JWT: jwts,
+	}
+}
+
+func jwtAuthenticator(issuerURL, audience string, caBundle []byte) apiserverv1beta1.JWTAuthenticator {
+	emptyPrefix := ""
+	return apiserverv1beta1.JWTAuthenticator{
+		Issuer: apiserverv1beta1.Issuer{
+			URL:                  issuerURL,
+			Audiences:            []string{audience},
+			CertificateAuthority: string(caBundle),
+		},
+		ClaimMappings: apiserverv1beta1.ClaimMappings{
+			Username: apiserverv1beta1.PrefixedClaimOrExpression{Claim: "email", Prefix: &emptyPrefix},
+			Groups:   apiserverv1beta1.PrefixedClaimOrExpression{Claim: "groups", Prefix: &emptyPrefix},
+		},
+	}
+}
+
+func configMapVolume(name string) corev1.Volume {
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: name},
+			},
+		},
+	}
+}

--- a/test/e2e/suite/cases/doc.go
+++ b/test/e2e/suite/cases/doc.go
@@ -3,6 +3,7 @@ package cases
 
 import (
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/audit"
+	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/authconfig"
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/headers"
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/impersonation"
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/passthrough"

--- a/test/e2e/suite/cases/sharedtests/sharedtests.go
+++ b/test/e2e/suite/cases/sharedtests/sharedtests.go
@@ -1,0 +1,89 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+// Package sharedtests defines token-validation Ginkgo cases that must pass
+// against any proxy deployment — OIDC-flags or AuthenticationConfiguration.
+// Callers deploy the proxy in the desired mode, then register these cases.
+package sharedtests
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
+	"github.com/jetstack/kube-oidc-proxy/test/util"
+)
+
+// RunTokenValidationTests registers Ginkgo It blocks exercising the proxy's
+// token-validation behaviour against the framework's primary issuer.
+func RunTokenValidationTests(f *framework.Framework) {
+	It("rejects a missing token", func() {
+		expectUnauthorized(f, f.IssuerKeyBundle(), nil)
+	})
+
+	It("rejects a malformed token", func() {
+		expectUnauthorized(f, f.IssuerKeyBundle(), []byte("bad token"))
+	})
+
+	It("rejects a token from an unknown issuer", func() {
+		badURL, err := url.Parse("incorrect-issuer.io")
+		Expect(err).NotTo(HaveOccurred())
+		expectUnauthorized(f, f.IssuerKeyBundle(),
+			f.Helper().NewTokenPayload(badURL, f.ClientID(), time.Now().Add(time.Minute)))
+	})
+
+	It("rejects a token with a wrong audience", func() {
+		expectUnauthorized(f, f.IssuerKeyBundle(),
+			f.Helper().NewTokenPayload(f.IssuerURL(), "wrong-aud", time.Now().Add(time.Minute)))
+	})
+
+	It("rejects an expired token", func() {
+		expectUnauthorized(f, f.IssuerKeyBundle(),
+			f.Helper().NewTokenPayload(f.IssuerURL(), f.ClientID(), time.Now()))
+	})
+
+	It("accepts a valid token from the primary issuer", func() {
+		_, err := f.NewProxyClient().CoreV1().Pods(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
+		if !k8sErrors.IsForbidden(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+}
+
+// ExpectProxyAuthenticated signs payload with keyBundle and asserts the proxy
+// did not reject the token. Downstream Kubernetes authorization is not
+// asserted, so 403 counts as success.
+func ExpectProxyAuthenticated(f *framework.Framework, keyBundle *util.KeyBundle, payload []byte) {
+	_, resp := proxyGetPods(f, keyBundle, payload)
+	Expect(resp.StatusCode).NotTo(Equal(http.StatusUnauthorized),
+		"token should be authenticated by proxy (got %d)", resp.StatusCode)
+}
+
+func expectUnauthorized(f *framework.Framework, keyBundle *util.KeyBundle, payload []byte) {
+	body, resp := proxyGetPods(f, keyBundle, payload)
+	body = bytes.TrimSpace(body)
+	if resp.StatusCode != http.StatusUnauthorized || !bytes.Equal(body, []byte("Unauthorized")) {
+		Expect(fmt.Errorf("expected 401 Unauthorized, got %d %q",
+			resp.StatusCode, body)).NotTo(HaveOccurred())
+	}
+}
+
+func proxyGetPods(f *framework.Framework, keyBundle *util.KeyBundle, payload []byte) ([]byte, *http.Response) {
+	signedToken, err := f.Helper().SignToken(keyBundle, payload)
+	Expect(err).NotTo(HaveOccurred())
+
+	proxyConfig := f.NewProxyRestConfig()
+	target := fmt.Sprintf("%s/api/v1/namespaces/%s/pods", proxyConfig.Host, f.Namespace.Name)
+
+	body, resp, err := f.Helper().NewRequester(proxyConfig.Transport, signedToken).Get(target)
+	Expect(err).NotTo(HaveOccurred())
+	return body, resp
+}

--- a/test/e2e/suite/cases/token/token.go
+++ b/test/e2e/suite/cases/token/token.go
@@ -2,78 +2,11 @@
 package token
 
 import (
-	"bytes"
-	"context"
-	"fmt"
-	"net/http"
-	"net/url"
-	"time"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
+	"github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/sharedtests"
 )
 
 var _ = framework.CasesDescribe("Token", func() {
 	f := framework.NewDefaultFramework("token")
-
-	It("should error when tokens are wrong for the issuer", func() {
-		By("No token should error")
-		expectProxyUnauthorized(f, nil)
-
-		By("Bad token should error")
-		expectProxyUnauthorized(f, []byte("bad token"))
-
-		By("Wrong issuer should error")
-		badURL, err := url.Parse("incorrect-issuer.io")
-		Expect(err).NotTo(HaveOccurred())
-
-		expectProxyUnauthorized(f, f.Helper().NewTokenPayload(
-			badURL, f.ClientID(), time.Now().Add(time.Minute)))
-
-		By("Wrong audience should error")
-		expectProxyUnauthorized(f, f.Helper().NewTokenPayload(
-			f.IssuerURL(), "wrong-aud", time.Now().Add(time.Minute)))
-
-		By("Token expires now")
-		expectProxyUnauthorized(f, f.Helper().NewTokenPayload(
-			f.IssuerURL(), f.ClientID(), time.Now()))
-
-		By("Valid token should return Kubernetes forbidden")
-		client := f.NewProxyClient()
-
-		// If does not return with Kubernetes forbidden error then error
-		_, err = client.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
-		if !k8sErrors.IsForbidden(err) {
-			Expect(err).NotTo(HaveOccurred())
-		}
-	})
+	sharedtests.RunTokenValidationTests(f)
 })
-
-func expectProxyUnauthorized(f *framework.Framework, tokenPayload []byte) {
-	// Build client using given token payload
-	signedToken, err := f.Helper().SignToken(f.IssuerKeyBundle(), tokenPayload)
-	Expect(err).NotTo(HaveOccurred())
-
-	proxyConfig := f.NewProxyRestConfig()
-	requester := f.Helper().NewRequester(proxyConfig.Transport, signedToken)
-
-	// Send request with signed token to proxy
-	target := fmt.Sprintf("%s/api/v1/namespaces/%s/pods",
-		proxyConfig.Host, f.Namespace.Name)
-
-	body, resp, err := requester.Get(target)
-	body = bytes.TrimSpace(body)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Check body and status code the token was rejected
-	if resp.StatusCode != http.StatusUnauthorized ||
-		!bytes.Equal(body, []byte("Unauthorized")) {
-		Expect(fmt.Errorf("expected status code %d with body Unauthorized, got= %d %q",
-			http.StatusUnauthorized, resp.StatusCode, body)).NotTo(HaveOccurred())
-	}
-}


### PR DESCRIPTION
## What this is

Multi-issuer OIDC support using the standard Kubernetes structured
`AuthenticationConfiguration` — the feature discussed in #81 and #85. This PR
does not compete with those: it **merges #85 verbatim (authorship preserved)**
and layers the remaining hardening on top, aiming to be the "TLC" this change
still needed per the maintainer's comments.

Credit to @BaptisteLalanne (#85) for the core implementation this builds on,
and @elkh510 (#81) for starting the effort.

## Why the config-file approach

As requested in the #81 review: no custom config formats — full parity with
kube-apiserver's `--authentication-config` (`apiserver.config.k8s.io`),
mutually exclusive with the `--oidc-*` flags, which keep working unchanged.
On managed clusters (EKS/GKE/DOKS) where apiserver flags can't be touched,
this is the only way to accept JWTs from multiple identity providers.

## What this adds on top of #85

- **Strict, versioned config loading** — scheme-based decode accepting both
  `v1` (GA) and `v1beta1`, converting to the internal type. Unknown/misspelled
  fields are rejected at startup instead of silently ignored; wrong `kind`
  fails loudly.
- **Whole-document validation** — runs the upstream
  `ValidateAuthenticationConfiguration` before building authenticators:
  duplicate issuer URLs across entries and invalid CEL expressions become one
  aggregated startup error. A populated `anonymous:` section is rejected
  explicitly (not supported by the proxy).
- **Shared CEL compiler** — one compiler instance for document validation and
  all `oidc.New` calls (matching kube-apiserver), instead of per-issuer
  environments.
- **Configurable readiness** — by default the pod reports ready once at least
  one issuer's JWKS is fetched; pending issuers are logged (with per-issuer
  transition lines) and keep initializing in the background, so a single IdP
  outage can't block a rollout for every other system.
  `--readiness-require-all-issuers` restores the strict all-issuers gate.
- **Helm** — the auth config is checksum-annotated on the Deployment (config
  edits roll the pods), `oidc.*` args/env are gated off in config-file mode so
  leftover legacy values can't crash-loop the proxy on the mutual-exclusivity
  check, and `readinessRequireAllIssuers` is exposed.
- **Docs** — new `docs/tasks/multi-issuer.md`: config format, CEL examples
  (incl. synthesizing groups for GitHub Actions tokens, which carry no groups
  claim), RBAC patterns, and why distinct per-issuer username/groups prefixes
  are mandatory in multi-issuer setups.
- **Tests** — per the #81 review ask, both levels and both directions:
  unit tables for the loader failure matrix (v1/v1beta1 accepted; wrong kind,
  unknown field, duplicate issuers, invalid CEL, anonymous, empty jwt list all
  rejected), readiness in both modes incl. stickiness and post-ready probing,
  and the e2e `authconfig` suite from #85 switched to exercise the GA `v1`
  config path.

## Compatibility

No breaking changes: existing `--oidc-*` deployments behave identically
(single authenticator, file-based CA semantics, `--oidc-signing-algs`
honored). The config-file path uses `AllValidSigningAlgorithms()`, matching
kube-apiserver. No new module dependencies; k8s.io/* stay at v0.36.0.

## Validation

Unit suites pass (probe/options/app additionally verified under `-race`);
`helm lint` plus renders in both modes; live smoke test on kind with real
GitHub Actions OIDC tokens — `kubectl auth whoami` through the proxy returns
the CEL-mapped username and synthesized `github:<owner>` group, wrong-audience
tokens get 401.

Happy to squash, split, or rework any of this to fit how you'd prefer to land
it alongside #85.
