### PR TITLE
Add support to the Helm chart for setting Security Context settings.

### DIFF
--- a/deploy/charts/kube-oidc-proxy/Chart.yaml
+++ b/deploy/charts/kube-oidc-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.0.0"
 description: A Helm chart for kube-oidc-proxy
 home: https://github.com/jetstack/kube-oidc-proxy
 name: kube-oidc-proxy
-version: 0.3.2
+version: 0.4.0
 maintainers:
 - name: mhrabovcin
 - name: joshvanl

--- a/deploy/charts/kube-oidc-proxy/templates/deployment.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/deployment.yaml
@@ -23,10 +23,18 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "kube-oidc-proxy.fullname" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 8443
         - containerPort: 8080

--- a/deploy/charts/kube-oidc-proxy/values.yaml
+++ b/deploy/charts/kube-oidc-proxy/values.yaml
@@ -13,6 +13,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+
 service:
   type: ClusterIP
   port: 443


### PR DESCRIPTION
This commit adds default Security Context settings at both the Pod and Container levels that meet the Kubernetes Pod Security Standards at both the Baseline and Restricted levels.

These have no negative impact on the out of the box running of kube-oidc-proxy.

These can be overridden as normal via Helm values.